### PR TITLE
Use view instead of internal copy for parsing

### DIFF
--- a/Src/.gitignore
+++ b/Src/.gitignore
@@ -9,3 +9,4 @@ Debug
 Release
 packages
 .vs
+*.swp

--- a/Src/.gitignore
+++ b/Src/.gitignore
@@ -9,4 +9,9 @@ Debug
 Release
 packages
 .vs
+
+# editor
 *.swp
+*.ycm_extra_conf.py*
+compile_commands.json
+.cache

--- a/Src/AttestationLibrary/src/QuoteVerification.cpp
+++ b/Src/AttestationLibrary/src/QuoteVerification.cpp
@@ -41,6 +41,7 @@
 #include "QuoteVerification/QuoteConstants.h"
 #include "QuoteVerification/QuoteParsers.h"
 
+#include "Utils/BufferView.h"
 #include "Verifiers/PckCertVerifier.h"
 #include "Verifiers/PckCrlVerifier.h"
 #include "Verifiers/TCBInfoVerifier.h"
@@ -55,6 +56,7 @@
 #include <SgxEcdsaAttestation/QuoteVerification.h>
 #include <Version/Version.h>
 #include <Utils/Logger.h>
+
 
 // On Windows in one of headers STATUS_INVALID_PARAMETER macro is defined and it conflicts with our status name so undef it.
 #undef STATUS_INVALID_PARAMETER
@@ -355,11 +357,11 @@ Status sgxAttestationVerifyQuote(const uint8_t* rawQuote, uint32_t quoteSize, co
    
     // We totally trust user on this, it should be explicitly and clearly
     // mentioned in doc, is there any max quote len other than numeric_limit<uint32_t>::max() ?
-    const std::vector<uint8_t> vecQuote(rawQuote, std::next(rawQuote, quoteSize));
+    const BufferView quoteView(rawQuote, quoteSize);
 
     /// 4.1.2.4.2
     dcap::Quote quote;
-    if(!quote.parse(vecQuote) || !quote.validate())
+    if(!quote.parse(quoteView) || !quote.validate())
     {
         LOG_ERROR("Quote format verification failure");
         return Status::STATUS_UNSUPPORTED_QUOTE_FORMAT;
@@ -430,7 +432,7 @@ Status sgxAttestationVerifyEnclaveReport(const uint8_t* enclaveReport, const cha
     }
 
     /// 4.1.2.9.1
-    const std::vector<uint8_t> vecEnclaveReport(enclaveReport, enclaveReport + dcap::constants::ENCLAVE_REPORT_BYTE_LEN);
+    const BufferView vecEnclaveReport(enclaveReport, dcap::constants::ENCLAVE_REPORT_BYTE_LEN); // size not taken as in input ????
     dcap::EnclaveReport eReport{};
     auto from = vecEnclaveReport.cbegin();
     auto end = vecEnclaveReport.cend();
@@ -445,6 +447,7 @@ Status sgxAttestationVerifyEnclaveReport(const uint8_t* enclaveReport, const cha
 
     if(from != end)
     {
+        // end - from log is nonsense and only make sense if iterator did not pass end which potentiantially is only half a case
         LOG_ERROR("Enclave Report parsing as binary data representation failure. EnclaveReport could not be iterated through {} bytes", end - from);
         return STATUS_SGX_ENCLAVE_REPORT_UNSUPPORTED_FORMAT;
     }
@@ -479,10 +482,10 @@ Status sgxAttestationGetQECertificationDataSize(
 
     // We totally trust user on this, it should be explicitly and clearly
     // mentioned in doc, is there any max quote len other than numeric_limit<uint32_t>::max() ?
-    const std::vector<uint8_t> vecQuote(rawQuote, std::next(rawQuote, quoteSize));
+    const BufferView quoteView(rawQuote, quoteSize);
 
     dcap::Quote quote;
-    if(!quote.parse(vecQuote) || !quote.validate())
+    if(!quote.parse(quoteView) || !quote.validate())
     {
         LOG_ERROR("Can't parse or validate quote");
         return Status::STATUS_UNSUPPORTED_QUOTE_FORMAT;
@@ -510,11 +513,11 @@ Status sgxAttestationGetQECertificationData(
 
     // We totally trust user on this, it should be explicitly and clearly
     // mentioned in doc, is there any max quote len other than numeric_limit<uint32_t>::max() ?
-    const std::vector<uint8_t> vecQuote(rawQuote, std::next(rawQuote, quoteSize));
+    const dcap::BufferView quoteView(rawQuote, quoteSize);
 
     dcap::Quote quote;
 
-    if(!quote.parse(vecQuote) || !quote.validate())
+    if(!quote.parse(quoteView) || !quote.validate())
     {
         LOG_ERROR("Can't parse or validate quote");
         return STATUS_UNSUPPORTED_QUOTE_FORMAT;

--- a/Src/AttestationLibrary/src/QuoteVerification/Quote.cpp
+++ b/Src/AttestationLibrary/src/QuoteVerification/Quote.cpp
@@ -31,6 +31,7 @@
 
 #include "Quote.h"
 #include "QuoteParsers.h"
+#include "Utils/BufferView.h"
 #include "Utils/Logger.h"
 
 #include <algorithm>
@@ -39,7 +40,7 @@
 namespace intel { namespace sgx { namespace dcap {
 using namespace constants;
 
-bool Quote::parse(const std::vector<uint8_t>& rawQuote)
+bool Quote::parse(const BufferView &rawQuote)
 {
     if(rawQuote.size() < QUOTE_MIN_BYTE_LEN)
     {
@@ -63,7 +64,7 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
 
     if (localHeader.version > constants::QUOTE_VERSION_4)
     {
-        if (!copyAndAdvance(localBody, from, BODY_BYTE_SIZE, rawQuote.end()))
+        if (!copyAndAdvance(localBody, from, BODY_BYTE_SIZE, rawQuote.cend()))
         {
             LOG_ERROR("Can't read SGX report body from quote. Expected size: {}", BODY_BYTE_SIZE);
             return false;
@@ -76,7 +77,7 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
                     LOG_ERROR("Unexpected SGX enclave report size. Expected size: {}", ENCLAVE_REPORT_BYTE_LEN);
                     return false;
                 }
-                if (!copyAndAdvance(localEnclaveReport, from, ENCLAVE_REPORT_BYTE_LEN, rawQuote.end()))
+                if (!copyAndAdvance(localEnclaveReport, from, ENCLAVE_REPORT_BYTE_LEN, rawQuote.cend()))
                 {
                     LOG_ERROR("Can't read SGX enclave report from quote. Expected size: {}", ENCLAVE_REPORT_BYTE_LEN);
                     return false;
@@ -89,7 +90,7 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
                     LOG_ERROR("Unexpected TDX TD Report 1.0 size. Expected size: {}", TD_REPORT10_BYTE_LEN);
                     return false;
                 }
-                if (!copyAndAdvance(localTdReport10, from, TD_REPORT10_BYTE_LEN, rawQuote.end()))
+                if (!copyAndAdvance(localTdReport10, from, TD_REPORT10_BYTE_LEN, rawQuote.cend()))
                 {
                     LOG_ERROR("Can't read TDX TD Report 1.0 from quote. Expected size: {}", TD_REPORT10_BYTE_LEN);
                     return false;
@@ -102,7 +103,7 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
                     LOG_ERROR("Unexpected TDX TD Report 1.5 size. Expected size: {}", TD_REPORT15_BYTE_LEN);
                     return false;
                 }
-                if (!copyAndAdvance(localTdReport15, from, TD_REPORT15_BYTE_LEN, rawQuote.end()))
+                if (!copyAndAdvance(localTdReport15, from, TD_REPORT15_BYTE_LEN, rawQuote.cend()))
                 {
                     LOG_ERROR("Can't read TDX TD Report 1.5 from quote. Expected size: {}", TD_REPORT10_BYTE_LEN);
                     return false;
@@ -117,7 +118,7 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
     {
         if (localHeader.teeType == TEE_TYPE_SGX)
         {
-            if (!copyAndAdvance(localEnclaveReport, from, ENCLAVE_REPORT_BYTE_LEN, rawQuote.end()))
+            if (!copyAndAdvance(localEnclaveReport, from, ENCLAVE_REPORT_BYTE_LEN, rawQuote.cend()))
             {
                 LOG_ERROR("Can't read SGX enclave report from quote. Expected size: {}", ENCLAVE_REPORT_BYTE_LEN);
                 return false;
@@ -126,7 +127,7 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
         }
         else if (localHeader.teeType == TEE_TYPE_TDX)
         {
-            if (!copyAndAdvance(localTdReport10, from, TD_REPORT10_BYTE_LEN, rawQuote.end()))
+            if (!copyAndAdvance(localTdReport10, from, TD_REPORT10_BYTE_LEN, rawQuote.cend()))
             {
                 LOG_ERROR("Can't read TDX TD Report 1.0 from quote. Expected size: {}", TD_REPORT10_BYTE_LEN);
                 return false;
@@ -136,11 +137,11 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
     }
 
     uint32_t localAuthDataSize = 0;
-    if (!copyAndAdvance(localAuthDataSize, from, rawQuote.end())) {
+    if (!copyAndAdvance(localAuthDataSize, from, rawQuote.cend())) {
         LOG_ERROR("Can't read auth data size  from quote.");
         return false;
     }
-    const auto remainingDistance = std::distance(from, rawQuote.end());
+    const auto remainingDistance = std::distance(from, rawQuote.cend());
     if(localAuthDataSize > remainingDistance)
     {
         LOG_ERROR("Declared auth data size {} is bigger than remaining buffer size {}", localAuthDataSize, remainingDistance);
@@ -151,7 +152,7 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
     Ecdsa256BitQuoteV4AuthData localQuoteV4Auth{};
     if (localHeader.version == constants::QUOTE_VERSION_3)
     {
-        if (!copyAndAdvance(localQuoteV3Auth, from, static_cast<size_t>(localAuthDataSize), rawQuote.end()))
+        if (!copyAndAdvance(localQuoteV3Auth, from, static_cast<size_t>(localAuthDataSize), rawQuote.cend()))
         {
             LOG_ERROR("Can't read QUOTE v3 Auth data. Expected size: {}", localAuthDataSize);
             return false;
@@ -165,16 +166,17 @@ bool Quote::parse(const std::vector<uint8_t>& rawQuote)
     }
     else if (localHeader.version > constants::QUOTE_VERSION_3)
     {
-        if (!copyAndAdvance(localQuoteV4Auth, from, static_cast<size_t>(localAuthDataSize), rawQuote.end()))
+        if (!copyAndAdvance(localQuoteV4Auth, from, static_cast<size_t>(localAuthDataSize), rawQuote.cend()))
         {
             LOG_ERROR("Can't read QUOTE v4 Auth data. Expected size: {}", localAuthDataSize);
             return false;
         }
         
-        const auto reportBytes = localQuoteV4Auth.certificationData.data;
-        auto beg = reportBytes.cbegin();
+        const auto &reportBytes = localQuoteV4Auth.certificationData.data;
+        dcap::BufferView view(reportBytes.data(), reportBytes.size());
+        auto beg = view.cbegin();
         QEReportCertificationData qeReportData;
-        if (!qeReportData.insert(beg, reportBytes.cend()))
+        if (!qeReportData.insert(beg, view.cend()))
         {
             return false;
         }
@@ -401,12 +403,11 @@ const std::array<uint8_t, 8>& Quote::getSeamAttributes() const
     }
 }
 
-std::vector<uint8_t> Quote::getDataToSignatureVerification(const std::vector<uint8_t>& rawQuote,
-                                                           const std::vector<uint8_t>::difference_type sizeToCopy) const
+std::vector<uint8_t> Quote::getDataToSignatureVerification(const BufferView &rawQuote, const BufferView::difference_type sizeToCopy) const
 {
     // private method, we call it at the end of parsing, so
     // here we assume format is valid
-    std::vector<uint8_t> ret(rawQuote.begin(), std::next(rawQuote.begin(), sizeToCopy));
+    std::vector<uint8_t> ret(rawQuote.cbegin(), std::next(rawQuote.cbegin(), sizeToCopy));
     return ret;
 }
 

--- a/Src/AttestationLibrary/src/QuoteVerification/Quote.h
+++ b/Src/AttestationLibrary/src/QuoteVerification/Quote.h
@@ -33,6 +33,7 @@
 #define INTEL_SGX_QVL_QUOTE_H_
 
 #include "QuoteStructures.h"
+#include <Utils/BufferView.h>
 
 namespace intel { namespace sgx { namespace dcap {
 using namespace intel::sgx::dcap::quote;
@@ -40,7 +41,7 @@ using namespace intel::sgx::dcap::quote;
 class Quote
 {
 public:
-    bool parse(const std::vector<uint8_t>& rawQuote);
+    bool parse(const BufferView &rawQuote);
 
     bool validate() const;
 
@@ -87,8 +88,7 @@ protected:
     std::array<uint8_t, constants::ECDSA_SIGNATURE_BYTE_LEN> quoteSignature{};
 
 private:
-    std::vector<uint8_t> getDataToSignatureVerification(const std::vector<uint8_t>& rawQuote,
-                                                        const std::vector<uint8_t>::difference_type) const;
+    std::vector<uint8_t> getDataToSignatureVerification(const BufferView &rawQuote, const BufferView::difference_type) const;
 };
 
 }}} // namespace intel { namespace sgx { namespace dcap { namespace test {

--- a/Src/AttestationLibrary/src/QuoteVerification/QuoteParsers.h
+++ b/Src/AttestationLibrary/src/QuoteVerification/QuoteParsers.h
@@ -32,15 +32,14 @@
 #ifndef INTEL_SGX_QVL_QUOTEPARSERS_H_
 #define INTEL_SGX_QVL_QUOTEPARSERS_H_
 
-#include <vector>
-#include "QuoteConstants.h"
 #include "ByteOperands.h"
+#include <Utils/BufferView.h>
 
 namespace intel { namespace sgx { namespace dcap { namespace quote {
 
 template<typename T>
-inline bool copyAndAdvance(T &val, std::vector<uint8_t>::const_iterator &from, size_t amount,
-                           const std::vector<uint8_t>::const_iterator &totalEnd) {
+inline bool copyAndAdvance(T &val, BufferView::const_iterator &from, size_t amount,
+                           const BufferView::const_iterator &totalEnd) {
     const auto available = std::distance(from, totalEnd);
     if (available < 0 || (unsigned) available < amount) {
         return false;
@@ -50,8 +49,8 @@ inline bool copyAndAdvance(T &val, std::vector<uint8_t>::const_iterator &from, s
 }
 
 template<size_t N>
-inline bool copyAndAdvance(std::array <uint8_t, N> &arr, std::vector<uint8_t>::const_iterator &from,
-                           const std::vector<uint8_t>::const_iterator &totalEnd) {
+inline bool copyAndAdvance(std::array <uint8_t, N> &arr, BufferView::const_iterator &from,
+                           const BufferView::const_iterator &totalEnd) {
     const auto capacity = std::distance(arr.cbegin(), arr.cend());
     if (std::distance(from, totalEnd) < capacity) {
         return false;
@@ -62,8 +61,8 @@ inline bool copyAndAdvance(std::array <uint8_t, N> &arr, std::vector<uint8_t>::c
     return true;
 }
 
-inline bool copyAndAdvance(uint16_t &val, std::vector<uint8_t>::const_iterator &from,
-                           const std::vector<uint8_t>::const_iterator &totalEnd) {
+inline bool copyAndAdvance(uint16_t &val, BufferView::const_iterator &from,
+                           const BufferView::const_iterator &totalEnd) {
     const auto available = std::distance(from, totalEnd);
     const auto capacity = sizeof(uint16_t);
     if (available < 0 || (unsigned) available < capacity) {
@@ -76,8 +75,8 @@ inline bool copyAndAdvance(uint16_t &val, std::vector<uint8_t>::const_iterator &
 }
 
 
-inline bool copyAndAdvance(uint32_t &val, std::vector<uint8_t>::const_iterator &position,
-                           const std::vector<uint8_t>::const_iterator &totalEnd) {
+inline bool copyAndAdvance(uint32_t &val, BufferView::const_iterator &position,
+                           const BufferView::const_iterator &totalEnd) {
     const auto available = std::distance(position, totalEnd);
     const auto capacity = sizeof(uint32_t);
     if (available < 0 || (unsigned) available < capacity) {

--- a/Src/AttestationLibrary/src/QuoteVerification/QuoteStructures.cpp
+++ b/Src/AttestationLibrary/src/QuoteVerification/QuoteStructures.cpp
@@ -9,7 +9,7 @@
 namespace intel { namespace sgx { namespace dcap { namespace quote {
 using namespace constants;
 
-bool Header::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool Header::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!copyAndAdvance(version, from, end)) { return false; }
     if (!copyAndAdvance(attestationKeyType, from, end)) { return false; }
@@ -21,14 +21,14 @@ bool Header::insert(std::vector<uint8_t>::const_iterator& from, const std::vecto
     return true;
 }
 
-bool Body::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool Body::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!copyAndAdvance(bodyType, from, end)) { return false; }
     if (!copyAndAdvance(size, from, end)) { return false; }
     return true;
 }
 
-bool EnclaveReport::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool EnclaveReport::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!copyAndAdvance(cpuSvn, from, end)) { return false; }
     if (!copyAndAdvance(miscSelect, from, end)) { return false; }
@@ -91,7 +91,7 @@ std::array<uint8_t,ENCLAVE_REPORT_BYTE_LEN> EnclaveReport::rawBlob() const
     return ret;
 }
 
-bool TDReport10::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool TDReport10::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!copyAndAdvance(teeTcbSvn, from, end)) { return false; }
     if (!copyAndAdvance(mrSeam, from, end)) { return false; }
@@ -164,7 +164,7 @@ std::array<uint8_t,TD_REPORT10_BYTE_LEN> TDReport10::rawBlob() const
     return ret;
 }
 
-bool TDReport15::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool TDReport15::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!TDReport10::insert(from, end)) return false;
     if (!copyAndAdvance(teeTcbSvn2, from, end)) { return false; }
@@ -190,17 +190,17 @@ std::array<uint8_t,TD_REPORT15_BYTE_LEN> TDReport15::rawBlob() const
     return ret;
 }
 
-bool Ecdsa256BitSignature::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool Ecdsa256BitSignature::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     return copyAndAdvance(signature, from, end);
 }
 
-bool Ecdsa256BitPubkey::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool Ecdsa256BitPubkey::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     return copyAndAdvance(pubKey, from, end);
 }
 
-bool QeAuthData::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool QeAuthData::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     const auto amount = static_cast<size_t>(std::distance(from, end));
     if(from > end || amount < QE_AUTH_DATA_SIZE_BYTE_LEN)
@@ -235,7 +235,7 @@ bool QeAuthData::insert(std::vector<uint8_t>::const_iterator& from, const std::v
     return true;
 }
 
-bool CertificationData::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool CertificationData::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     const auto minLen = CERTIFICATION_DATA_SIZE_BYTE_LEN + CERTIFICATION_DATA_TYPE_BYTE_LEN;
     const auto amount = static_cast<size_t>(std::distance(from, end));
@@ -267,7 +267,7 @@ bool CertificationData::insert(std::vector<uint8_t>::const_iterator& from, const
     return true;
 }
 
-bool QEReportCertificationData::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool QEReportCertificationData::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!copyAndAdvance(qeReport, from, ENCLAVE_REPORT_BYTE_LEN, end))
     {
@@ -321,7 +321,7 @@ bool QEReportCertificationData::insert(std::vector<uint8_t>::const_iterator& fro
     return true;
 }
 
-bool Ecdsa256BitQuoteV3AuthData::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool Ecdsa256BitQuoteV3AuthData::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!copyAndAdvance(ecdsa256BitSignature, from, ECDSA_SIGNATURE_BYTE_LEN, end)) { return false; }
     if (!copyAndAdvance(ecdsaAttestationKey, from, ECDSA_PUBKEY_BYTE_LEN, end)) { return false; }
@@ -358,7 +358,7 @@ bool Ecdsa256BitQuoteV3AuthData::insert(std::vector<uint8_t>::const_iterator& fr
     return true;
 }
 
-bool Ecdsa256BitQuoteV4AuthData::insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end)
+bool Ecdsa256BitQuoteV4AuthData::insert(BufferView::const_iterator& from, const BufferView::const_iterator& end)
 {
     if (!copyAndAdvance(ecdsa256BitSignature, from, ECDSA_SIGNATURE_BYTE_LEN, end)) { return false; }
     if (!copyAndAdvance(ecdsaAttestationKey, from, ECDSA_PUBKEY_BYTE_LEN, end)) { return false; }

--- a/Src/AttestationLibrary/src/QuoteVerification/QuoteStructures.h
+++ b/Src/AttestationLibrary/src/QuoteVerification/QuoteStructures.h
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "QuoteConstants.h"
+#include <Utils/BufferView.h>
 
 namespace intel { namespace sgx { namespace dcap { namespace quote {
 
@@ -49,7 +50,7 @@ struct Header
     std::array<uint8_t, 16> qeVendorId;
     std::array<uint8_t, 20> userData;
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct Body
@@ -57,7 +58,7 @@ struct Body
     uint16_t bodyType;
     uint32_t size;
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct EnclaveReport
@@ -75,7 +76,7 @@ struct EnclaveReport
     std::array<uint8_t, 60> reserved4;
     std::array<uint8_t, 64> reportData;
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
     std::array<uint8_t, constants::ENCLAVE_REPORT_BYTE_LEN> rawBlob() const;
 };
 
@@ -97,7 +98,7 @@ struct TDReport10
     std::array<uint8_t, 48> rtMr3;
     std::array<uint8_t, 64> reportData;
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 
     std::array<uint8_t, constants::TD_REPORT10_BYTE_LEN> rawBlob() const;
 };
@@ -107,7 +108,7 @@ struct TDReport15 : public TDReport10
     std::array<uint8_t, 16> teeTcbSvn2;
     std::array<uint8_t, 48> mrServiceTd;
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
     std::array<uint8_t, constants::TD_REPORT15_BYTE_LEN> rawBlob() const;
 };
 
@@ -115,21 +116,21 @@ struct Ecdsa256BitSignature
 {
     std::array<uint8_t, dcap::constants::ECDSA_P256_SIGNATURE_BYTE_LEN> signature;
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct Ecdsa256BitPubkey
 {
     std::array<uint8_t, 64> pubKey;
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct QeAuthData
 {
     uint16_t parsedDataSize;
     std::vector<uint8_t> data;
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct CertificationData
@@ -137,7 +138,7 @@ struct CertificationData
     uint16_t type;
     uint32_t parsedDataSize;
     std::vector<uint8_t> data;
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct QEReportCertificationData
@@ -147,7 +148,7 @@ struct QEReportCertificationData
     QeAuthData qeAuthData{};
     CertificationData certificationData{};
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct Ecdsa256BitQuoteV3AuthData
@@ -160,7 +161,7 @@ struct Ecdsa256BitQuoteV3AuthData
     QeAuthData qeAuthData{};
     CertificationData certificationData{};
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 struct Ecdsa256BitQuoteV4AuthData
@@ -169,7 +170,7 @@ struct Ecdsa256BitQuoteV4AuthData
     Ecdsa256BitPubkey ecdsaAttestationKey{};
     CertificationData certificationData{};
 
-    bool insert(std::vector<uint8_t>::const_iterator& from, const std::vector<uint8_t>::const_iterator& end);
+    bool insert(BufferView::const_iterator& from, const BufferView::const_iterator& end);
 };
 
 }}}}

--- a/Src/AttestationLibrary/src/Utils/BufferView.h
+++ b/Src/AttestationLibrary/src/Utils/BufferView.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef SGXECDSAATTESTATION_BUFFERVIEW_H
+#define SGXECDSAATTESTATION_BUFFERVIEW_H
+
+#include <cstdint>
+#include <cstddef>
+
+namespace intel::sgx::dcap {
+
+class BufferView final
+{
+  const uint8_t *m_data{nullptr};
+  size_t m_size{0};
+
+public:
+  using iterator = uint8_t*;
+  using const_iterator = const uint8_t*;
+  using difference_type = std::ptrdiff_t;
+
+  BufferView(const uint8_t *data, size_t size)
+    : m_data{data}, m_size{size}
+  {}
+
+  size_t size() const { return m_size; }
+  
+  const_iterator cbegin() const { return m_data; }
+  const_iterator cend() const { return m_data + m_size; }
+
+  uint8_t operator[](size_t pos) const { return m_data[pos]; }
+
+};
+
+} //namespace intel::sgx::dcap
+
+#endif

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteUtils.h
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteUtils.h
@@ -1,9 +1,16 @@
 #ifndef SGXECDSAATTESTATION_TEST_QUOTE_UTILS_H_
 #define SGXECDSAATTESTATION_TEST_QUOTE_UTILS_H_
 
+#include "Utils/BufferView.h"
 #include <OpensslHelpers/Bytes.h>
 
 namespace intel { namespace sgx { namespace dcap { namespace test {
+
+struct TestQuote
+{
+  intel::sgx::dcap::BufferView quoteView;
+  Bytes quote;
+};
 
 static constexpr size_t QUOTE_HEADER_SIZE = 48;
 static constexpr size_t QUOTE_BODY_SIZE = 6;
@@ -54,6 +61,11 @@ Bytes toBytes(DataType &data) {
     auto bytes = reinterpret_cast<uint8_t *>(const_cast<typename std::remove_cv<DataType>::type *>(&data));
     retVal.insert(retVal.end(), bytes, bytes + sizeof(DataType));
     return retVal;
+}
+
+inline intel::sgx::dcap::BufferView getView(const std::vector<uint8_t> &buf)
+{
+  return intel::sgx::dcap::BufferView(buf.data(), buf.size());
 }
 
 }}}}

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3Generator.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3Generator.cpp
@@ -257,7 +257,7 @@ QuoteV3Generator& QuoteV3Generator::withCertificationData(uint16_t type, const B
 dcap::test::TestQuote QuoteV3Generator::buildQuote()
 {
   auto quote = header.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
-	return TestQuote {
+  return TestQuote {
     getView(quote),
     std::move(quote) 
   };

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3Generator.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3Generator.cpp
@@ -254,9 +254,13 @@ QuoteV3Generator& QuoteV3Generator::withCertificationData(uint16_t type, const B
     return *this;
 }
 
-Bytes QuoteV3Generator::buildQuote()
+dcap::test::TestQuote QuoteV3Generator::buildQuote()
 {
-	return header.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
+  auto quote = header.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
+	return TestQuote {
+    getView(quote),
+    std::move(quote) 
+  };
 }
 
 Bytes QuoteV3Generator::QuoteHeader::bytes() const

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3Generator.h
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3Generator.h
@@ -32,9 +32,10 @@
 #ifndef SGXECDSAATTESTATION_TEST_QUOTEV3_GENERATOR_H_
 #define SGXECDSAATTESTATION_TEST_QUOTEV3_GENERATOR_H_
 
+#include "QuoteUtils.h"
+
 #include <cstdint>
 #include <array>
-#include <vector>
 #include <OpensslHelpers/Bytes.h>
 
 namespace intel { namespace sgx { namespace dcap { namespace test {
@@ -148,8 +149,9 @@ public:
     QuoteV3Generator& withcertificationData(const CertificationData& certificationData);
     QuoteV3Generator& withCertificationData(uint16_t type, const Bytes& keyData);
 
-    Bytes buildQuote();
+    TestQuote buildQuote();
     Bytes buildTdxQuote();
+
 
 private:  
     QuoteHeader header;

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3GeneratorUT.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3GeneratorUT.cpp
@@ -29,6 +29,7 @@
  *
  */
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -36,6 +37,8 @@
 #include <SgxEcdsaAttestation/QuoteVerification.h>
 #include "QuoteV3Generator.h"
 #include "QuoteUtils.h"
+
+#include <Utils/BufferView.h>
 
 using namespace testing;
 using namespace ::intel::sgx::dcap;
@@ -46,7 +49,7 @@ struct QuoteV3GeneratorTests : public Test
 
 namespace {
 
-bool areBytesAtPosition(Bytes container, size_t position, const Bytes& bytes)
+bool areBytesAtPosition(const Bytes &container, size_t position, const Bytes& bytes)
 {
     if (bytes.size() + position > container.size())
     {
@@ -103,7 +106,7 @@ constexpr size_t ECDSA_ATTESTATION_KEY_POSITION =
 TEST_F(QuoteV3GeneratorTests, shouldProvideGeneratedBinaryQuote)
 {
     test::QuoteV3Generator generator;
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
     EXPECT_THAT(quote, SizeIs(test::QUOTE_V3_MINIMAL_SIZE));
 }
 
@@ -113,7 +116,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingQeSvn)
     uint16_t qeSvn = 55;
 
     generator.withQeSvn(qeSvn);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, DataAtPositionEq(QE_SVN_POSITION_IN_HEADER, qeSvn));
 }
@@ -124,7 +127,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingPceSvn)
     uint16_t pceSvn = 256;
 
     generator.withPceSvn(pceSvn);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, DataAtPositionEq(PCE_SVN_POSITION_IN_HEADER, pceSvn));
 }
@@ -136,7 +139,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowChainingMethods)
     uint16_t qeSvn = 88;
 
     generator.withQeSvn(qeSvn).withPceSvn(pceSvn);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, AllOf(DataAtPositionEq(QE_SVN_POSITION_IN_HEADER, qeSvn), DataAtPositionEq(PCE_SVN_POSITION_IN_HEADER, pceSvn)));
 }
@@ -147,7 +150,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingHeader)
     test::QuoteV3Generator::QuoteHeader header = {5, 1, 229, 0, 0, 823, {{0, 1, 4}}, {{20, 50, 88, 153}}};
 
     generator.withHeader(header);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, DataAtPositionEq(0, header));
 }
@@ -158,7 +161,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingBody)
     test::QuoteV3Generator::EnclaveReport er = {{{45, 88, 62}}, 2222, {{}}, {{32}}, {{'m', 'r', 'e'}}, {{}}, {{'m', 'r', 's'}}, {{}}, 4, 35, {{}}, {{99, 194, 78}}};
 
     generator.withEnclaveReport(er);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, DataAtPositionEq(BODY_POSITION, er));
 }
@@ -169,7 +172,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingQeReport)
     test::QuoteV3Generator::EnclaveReport er = {{{45, 88, 62}}, 2222, {{}}, {{32}}, {{'m', 'r', 'e'}}, {{}}, {{'m', 'r', 's'}}, {{}}, 4, 35, {{}}, {{99, 194, 78}}};
 
     generator.withQeReport(er);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, DataAtPositionEq(QE_REPORT_DATA_POSITION, er));
 }
@@ -180,7 +183,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingQeReportSignature)
     test::QuoteV3Generator::EcdsaSignature sign = {{"signature"}};
 
     generator.withQeReportSignature(sign);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, DataAtPositionEq(QE_REPORT_SIGNATURE_POSITION, sign));
 }
@@ -191,7 +194,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingEcdsaAttestationKey)
     test::QuoteV3Generator::EcdsaPublicKey key = {{"public key"}};
 
     generator.withAttestationKey(key);
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, DataAtPositionEq(ECDSA_ATTESTATION_KEY_POSITION, key));
 }
@@ -202,7 +205,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingEmptyPCKData)
     Bytes pckData{};
     generator.withCertificationData(1, pckData);
 
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, SizeIs(test::QUOTE_V3_MINIMAL_SIZE));
 }
@@ -213,7 +216,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingArbitraryPCKData)
     Bytes pckData{'p', 'c', 'k', 'd', 'a', 't', 'a'};
     generator.withCertificationData(2, pckData);
 
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, SizeIs(test::QUOTE_V3_MINIMAL_SIZE + pckData.size()));
     EXPECT_THAT(quote,
@@ -228,7 +231,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingEmptyAuthData)
     Bytes authData{};
     generator.withQeAuthData(authData);
 
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, SizeIs(test::QUOTE_V3_MINIMAL_SIZE));
 }
@@ -239,7 +242,7 @@ TEST_F(QuoteV3GeneratorTests, shouldAllowSettingArbitraryAuthData)
     Bytes authData{'a', 'u', 't', 'h'};
     generator.withQeAuthData(authData);
 
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     EXPECT_THAT(quote, SizeIs(test::QUOTE_V3_MINIMAL_SIZE + authData.size()));
     EXPECT_THAT(quote,
@@ -258,5 +261,18 @@ TEST_F(QuoteV3GeneratorTests, withArbitraryPckDataShouldBeParsable)
     intel::sgx::dcap::Quote quote;
 
     // WHEN/THEN
-    ASSERT_TRUE(quote.parse(generatedQuote));
+    ASSERT_TRUE(quote.parse(generatedQuote.quoteView));
+}
+
+TEST_F(QuoteV3GeneratorTests, checkBufferViewGeneration)
+{
+    // GIVEN
+    test::QuoteV3Generator generator;
+    const Bytes pckData{'p', 'c', 'k', 'd', 'a', 't', 'a'};
+
+    // WHEN
+    const auto bufferView = test::getView(pckData);
+
+    // WHEN
+    ASSERT_TRUE( std::equal(pckData.begin(), pckData.end(), bufferView.cbegin(), bufferView.cend()) );
 }

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3GeneratorUT.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV3GeneratorUT.cpp
@@ -264,15 +264,3 @@ TEST_F(QuoteV3GeneratorTests, withArbitraryPckDataShouldBeParsable)
     ASSERT_TRUE(quote.parse(generatedQuote.quoteView));
 }
 
-TEST_F(QuoteV3GeneratorTests, checkBufferViewGeneration)
-{
-    // GIVEN
-    test::QuoteV3Generator generator;
-    const Bytes pckData{'p', 'c', 'k', 'd', 'a', 't', 'a'};
-
-    // WHEN
-    const auto bufferView = test::getView(pckData);
-
-    // WHEN
-    ASSERT_TRUE( std::equal(pckData.begin(), pckData.end(), bufferView.cbegin(), bufferView.cend()) );
-}

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4Generator.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4Generator.cpp
@@ -224,7 +224,7 @@ QuoteV4Generator& QuoteV4Generator::withCertificationData(uint16_t type, const B
 dcap::test::TestQuote QuoteV4Generator::buildSgxQuote()
 {
   auto quoteBytes = header.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
-	return dcap::test::TestQuote {
+  return dcap::test::TestQuote {
     dcap::test::getView(quoteBytes),
     std::move(quoteBytes)
   }; 

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4Generator.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4Generator.cpp
@@ -221,14 +221,22 @@ QuoteV4Generator& QuoteV4Generator::withCertificationData(uint16_t type, const B
     return *this;
 }
 
-Bytes QuoteV4Generator::buildSgxQuote()
+dcap::test::TestQuote QuoteV4Generator::buildSgxQuote()
 {
-	return header.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
+  auto quoteBytes = header.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
+	return dcap::test::TestQuote {
+    dcap::test::getView(quoteBytes),
+    std::move(quoteBytes)
+  }; 
 }
 
-Bytes QuoteV4Generator::buildTdxQuote()
+dcap::test::TestQuote QuoteV4Generator::buildTdxQuote()
 {
-    return header.bytes() + tdReport.bytes() + quoteAuthData.bytes();
+    auto quoteBytes = header.bytes() + tdReport.bytes() + quoteAuthData.bytes();
+    return dcap::test::TestQuote {
+      dcap::test::getView(quoteBytes),
+      std::move(quoteBytes)
+  };
 }
 
 Bytes QuoteV4Generator::QuoteHeader::bytes() const

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4Generator.h
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4Generator.h
@@ -32,9 +32,10 @@
 #ifndef SGXECDSAATTESTATION_TEST_QUOTEV4_GENERATOR_H_
 #define SGXECDSAATTESTATION_TEST_QUOTEV4_GENERATOR_H_
 
+#include "QuoteUtils.h"
+
 #include <cstdint>
 #include <array>
-#include <vector>
 #include <OpensslHelpers/Bytes.h>
 
 namespace intel { namespace sgx { namespace dcap { namespace test {
@@ -164,8 +165,8 @@ public:
     QuoteV4Generator& withCertificationData(const CertificationData& certificationData);
     QuoteV4Generator& withCertificationData(uint16_t type, const Bytes& keyData);
 
-    Bytes buildSgxQuote();
-    Bytes buildTdxQuote();
+    TestQuote buildSgxQuote();
+    TestQuote buildTdxQuote();
 
 private:
     QuoteHeader header;

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4GeneratorUT.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV4GeneratorUT.cpp
@@ -31,7 +31,6 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <random>
 
 #include <QuoteVerification/Quote.h>
 #include <SgxEcdsaAttestation/QuoteVerification.h>
@@ -56,14 +55,16 @@ std::array<uint8_t, N> randomByteArray()
     return arr;
 }
 
-bool areBytesAtPosition(Bytes container, size_t position, const Bytes& bytes)
+bool areBytesAtPosition(const Bytes &container, size_t position, const Bytes& bytes)
 {
+    using diff_type = typename Bytes::difference_type;
     if (bytes.size() + position > container.size())
     {
         return false;
     }
-    auto sliceBegin = std::next(container.cbegin(), (long) position);
-    auto sliceEnd = std::next(sliceBegin, (long) bytes.size());
+
+    auto sliceBegin = std::next(container.cbegin(), static_cast<diff_type>(position));
+    auto sliceEnd = std::next(sliceBegin, static_cast<diff_type>(bytes.size()));
     Bytes slice(sliceBegin, sliceEnd);
     return bytes == slice;
 }
@@ -72,7 +73,7 @@ MATCHER_P2(DataAtPositionEq, position, data,
     std::string("Data at position " + PrintToString(position) + (negation ? " isn't" : " is") + " equal to " + PrintToString(data)))
 {
     auto bytes = test::toBytes(data);
-    return areBytesAtPosition(arg, (size_t) position, bytes);
+    return areBytesAtPosition(arg, static_cast<size_t>(position), bytes);
 }
 
 MATCHER_P2(BytesAtPositionEq, position, bytes,
@@ -137,8 +138,8 @@ constexpr size_t CERTIFICATION_DATA_POSITION_TDX_QUOTE = ATTESTATION_KEY_POSITIO
 TEST_F(QuoteV4GeneratorTests, shouldProvideGeneratedBinaryQuote)
 {
     test::QuoteV4Generator generator;
-    auto quote = generator.buildSgxQuote();
-    EXPECT_THAT(quote, SizeIs(test::QUOTE_V4_MINIMAL_SIZE));
+    auto [sgxQuoteView, sgxQuote] = generator.buildSgxQuote();
+    EXPECT_THAT(sgxQuote, SizeIs(test::QUOTE_V4_MINIMAL_SIZE));
 }
 
 TEST_F(QuoteV4GeneratorTests, shouldAllowSettingHeader)
@@ -160,8 +161,8 @@ TEST_F(QuoteV4GeneratorTests, shouldAllowSettingHeader)
     header.userData = userData;
 
     generator.withHeader(header);
-    auto sgxQuote = generator.buildSgxQuote();
-    auto tdxQuote = generator.buildTdxQuote();
+    auto [sgxQuoteView, sgxQuote] = generator.buildSgxQuote();
+    auto [tdxQuoteView, tdxQuote] = generator.buildTdxQuote();
 
     EXPECT_THAT(sgxQuote, DataAtPositionEq(VERSION_POSITION_IN_QUOTE, version));
     EXPECT_THAT(sgxQuote, DataAtPositionEq(ATTESTATION_KEY_TYPE_POSITION_IN_QUOTE, attestationKeyType));
@@ -210,7 +211,7 @@ TEST_F(QuoteV4GeneratorTests, shouldAllowSettingEnclaveReport)
     enclaveReport.reportData = reportedData;
 
     generator.withEnclaveReport(enclaveReport);
-    auto sgxQuote = generator.buildSgxQuote();
+    auto [sgxQuoteView, sgxQuote] = generator.buildSgxQuote();
 
     EXPECT_THAT(sgxQuote, DataAtPositionEq(CPUSVN_POSITION_IN_QUOTE, cpuSvn));
     EXPECT_THAT(sgxQuote, DataAtPositionEq(MISCSELECT_POSITION_IN_QUOTE, miscSelect));
@@ -264,7 +265,7 @@ TEST_F(QuoteV4GeneratorTests, shouldAllowSettingTDReport)
     tdReport.reportData = reportedData;
 
     generator.withTDReport(tdReport);
-    auto tdxQuote = generator.buildTdxQuote();
+    auto [tdxQuoteView, tdxQuote] = generator.buildTdxQuote();
 
     EXPECT_THAT(tdxQuote, DataAtPositionEq(TEE_TCB_SVN_POSITION_IN_QUOTE, teeTcbSvn));
     EXPECT_THAT(tdxQuote, DataAtPositionEq(MRSEAM_POSITION_IN_QUOTE, mrSeam));
@@ -290,8 +291,8 @@ TEST_F(QuoteV4GeneratorTests, shouldAllowSettingAuthDataSize)
     test::QuoteV4Generator generator;
 
     generator.withAuthDataSize(789);
-    auto tdxQuote = generator.buildTdxQuote();
-    auto sgxQuote = generator.buildSgxQuote();
+    auto [tdxQuoteView, tdxQuote] = generator.buildTdxQuote();
+    auto [sgxQuoteView, sgxQuote] = generator.buildSgxQuote();
 
     EXPECT_THAT(tdxQuote, DataAtPositionEq(AUTH_DATA_SIZE_POSITION_IN_TDX_QUOTE, authDataSize));
     EXPECT_THAT(sgxQuote, DataAtPositionEq(AUTH_DATA_SIZE_POSITION_IN_SGX_QUOTE, authDataSize));
@@ -318,8 +319,8 @@ TEST_F(QuoteV4GeneratorTests, shouldAllowSettingAuthData)
     authData.certificationData = certificationData;
 
     generator.withAuthData(authData);
-    auto tdxQuote = generator.buildTdxQuote();
-    auto sgxQuote = generator.buildSgxQuote();
+    auto [tdxQuoteView, tdxQuote] = generator.buildTdxQuote();
+    auto [sgxQuoteView, sgxQuote] = generator.buildSgxQuote();
 
     EXPECT_THAT(tdxQuote, DataAtPositionEq(AUTH_DATA_SIZE_POSITION_IN_TDX_QUOTE, authDataSize));
     EXPECT_THAT(tdxQuote, DataAtPositionEq(QUOTE_SIGNATURE_POSITION_TDX_QUOTE, ecdsaSignature.signature));

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV5Generator.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV5Generator.cpp
@@ -246,19 +246,31 @@ QuoteV5Generator& QuoteV5Generator::withCertificationData(uint16_t type, const B
     return *this;
 }
 
-Bytes QuoteV5Generator::buildSgxQuote()
+dcap::test::TestQuote QuoteV5Generator::buildSgxQuote()
 {
-	return header.bytes() + body.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
+  auto quote = header.bytes() + body.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
+	return dcap::test::TestQuote{
+    dcap::test::getView(quote),
+    std::move(quote)
+  };
 }
 
-Bytes QuoteV5Generator::buildTdx10Quote()
+dcap::test::TestQuote QuoteV5Generator::buildTdx10Quote()
 {
-    return header.bytes() + body.bytes() + tdReport10.bytes() + quoteAuthData.bytes();
+  auto quote = header.bytes() + body.bytes() + tdReport10.bytes() + quoteAuthData.bytes();
+  return dcap::test::TestQuote{
+    dcap::test::getView(quote),
+    std::move(quote)
+  };
 }
 
-Bytes QuoteV5Generator::buildTdx15Quote()
+dcap::test::TestQuote QuoteV5Generator::buildTdx15Quote()
 {
-    return header.bytes() + body.bytes() + tdReport15.bytes() + quoteAuthData.bytes();
+  auto quote = header.bytes() + body.bytes() + tdReport15.bytes() + quoteAuthData.bytes();
+  return dcap::test::TestQuote{
+    dcap::test::getView(quote),
+    std::move(quote)
+  };
 }
 
 Bytes QuoteV5Generator::QuoteHeader::bytes() const

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV5Generator.cpp
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV5Generator.cpp
@@ -249,7 +249,7 @@ QuoteV5Generator& QuoteV5Generator::withCertificationData(uint16_t type, const B
 dcap::test::TestQuote QuoteV5Generator::buildSgxQuote()
 {
   auto quote = header.bytes() + body.bytes() + enclaveReport.bytes() + quoteAuthData.bytes();
-	return dcap::test::TestQuote{
+  return dcap::test::TestQuote{
     dcap::test::getView(quote),
     std::move(quote)
   };

--- a/Src/AttestationLibrary/test/CommonTestUtils/QuoteV5Generator.h
+++ b/Src/AttestationLibrary/test/CommonTestUtils/QuoteV5Generator.h
@@ -32,9 +32,10 @@
 #ifndef SGXECDSAATTESTATION_TEST_QuoteV5_GENERATOR_H_
 #define SGXECDSAATTESTATION_TEST_QuoteV5_GENERATOR_H_
 
+#include "QuoteUtils.h"
+
 #include <cstdint>
 #include <array>
-#include <vector>
 #include <OpensslHelpers/Bytes.h>
 
 namespace intel { namespace sgx { namespace dcap { namespace test {
@@ -182,9 +183,9 @@ public:
     QuoteV5Generator& withCertificationData(const CertificationData& certificationData);
     QuoteV5Generator& withCertificationData(uint16_t type, const Bytes& keyData);
 
-    Bytes buildSgxQuote();
-    Bytes buildTdx10Quote();
-    Bytes buildTdx15Quote();
+    dcap::test::TestQuote buildSgxQuote();
+    dcap::test::TestQuote buildTdx10Quote();
+    dcap::test::TestQuote buildTdx15Quote();
 
 private:
     QuoteHeader header;

--- a/Src/AttestationLibrary/test/IntegrationTests/VerifyQuoteIT.cpp
+++ b/Src/AttestationLibrary/test/IntegrationTests/VerifyQuoteIT.cpp
@@ -255,7 +255,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedQuoteFormatWhenQuoteSizeIsIncorrec
 {
     // GIVEN
     auto incorrectQouteSize = 0;
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
 
     // WHEN
     auto result = sgxAttestationVerifyQuote(quote.data(), (unsigned) incorrectQouteSize, placeHolder, placeHolder, placeHolder, placeHolder);
@@ -270,7 +270,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedQuoteFormatWhenQuoteHeaderVersionI
     QuoteV3Generator::QuoteHeader quoteHeader{};
     quoteHeader.version = 999;
     quoteV3Generator.withHeader(quoteHeader);
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
 
 
     // WHEN
@@ -303,7 +303,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedPckCertFormatWhenVerifyPckCertFail
     quoteV3Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV3Generator.getHeader().bytes(), quoteV3Generator.getEnclaveReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
     tcbInfoBodyBytes.insert(tcbInfoBodyBytes.end(), positiveTcbInfoV2JsonBody.begin(), positiveTcbInfoV2JsonBody.end());
@@ -328,7 +328,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedPckCertFormatWhenVerifyPckCertFail
 TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedPckCrlFormatWhenVerifyPckCrlFail)
 {
     // GIVEN
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
 
     // WHEN
@@ -341,7 +341,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedPckCrlFormatWhenVerifyPckCrlFail)
 TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedTcbInfoFormatWhenVerifyTcbInfoFail)
 {
     // GIVEN
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(cert);
 
@@ -355,7 +355,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedTcbInfoFormatWhenVerifyTcbInfoFail
 TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedQeIdentityFormatWhenVerifyQEidentityFail)
 {
     // GIVEN
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(cert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -375,7 +375,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedQeIdentityFormatWhenVerifyQEidenti
 TEST_F(VerifyQuoteIT, shouldReturnedUnsuportedQeIdentityFormatWhenQEIdentityIsWrong)
 {
     // GIVEN
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(cert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -415,7 +415,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifyQuoteV3Successffuly)
     quoteV3Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV3Generator.getHeader().bytes(), quoteV3Generator.getEnclaveReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -462,7 +462,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifyQuoteV3SuccessffulyWithNoQ
     quoteV3Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV3Generator.getHeader().bytes(), quoteV3Generator.getEnclaveReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -517,7 +517,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifySgxQuoteV4Successffuly)
     quoteV4Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV4Generator.getHeader().bytes(), quoteV4Generator.getEnclaveReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV4Generator.buildSgxQuote();
+    auto [sgxQuoteView, sgxQuote] = quoteV4Generator.buildSgxQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -534,7 +534,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifySgxQuoteV4Successffuly)
                                                                              signatureQE));
 
     // WHEN
-    auto result = sgxAttestationVerifyQuote(quote.data(), (uint32_t) quote.size(), pckPem.c_str(), pckCrl.c_str(),
+    auto result = sgxAttestationVerifyQuote(sgxQuote.data(), (uint32_t) sgxQuote.size(), pckPem.c_str(), pckCrl.c_str(),
                                             tcbInfoJsonWithSignature.c_str(), qeIdentityJsonWithSignature.c_str());
 
     // THEN
@@ -575,7 +575,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifySgxQuoteV4WithoutQeIdentit
     quoteV4Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV4Generator.getHeader().bytes(), quoteV4Generator.getEnclaveReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV4Generator.buildSgxQuote();
+    auto [sgxQuoteView, sgxQuote] = quoteV4Generator.buildSgxQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -585,7 +585,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifySgxQuoteV4WithoutQeIdentit
                                                          EcdsaSignatureGenerator::signatureToHexString(signatureTcb));
 
     // WHEN
-    auto result = sgxAttestationVerifyQuote(quote.data(), (uint32_t) quote.size(), pckPem.c_str(), pckCrl.c_str(),
+    auto result = sgxAttestationVerifyQuote(sgxQuote.data(), (uint32_t) sgxQuote.size(), pckPem.c_str(), pckCrl.c_str(),
                                             tcbInfoJsonWithSignature.c_str(), nullptr);
 
     // THEN
@@ -642,7 +642,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifyTdxQuoteV4Successfully)
     quoteV4Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV4Generator.getHeader().bytes(), quoteV4Generator.getTdReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV4Generator.buildTdxQuote();
+    const auto [view, quote] = quoteV4Generator.buildTdxQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -711,7 +711,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusTdxModuleMismatchWhenVerifyTdxQuoteV4W
     quoteV4Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV4Generator.getHeader().bytes(), quoteV4Generator.getTdReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV4Generator.buildTdxQuote();
+    const auto [view, quote] = quoteV4Generator.buildTdxQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -774,7 +774,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusTdxModuleMismatchWhenVerifyTdxQuoteV4W
     quoteV4Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV4Generator.getHeader().bytes(), quoteV4Generator.getTdReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV4Generator.buildTdxQuote();
+    const auto [view, quote] = quoteV4Generator.buildTdxQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -834,7 +834,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifyTdxQuoteV4WithoutQeIdentit
     quoteV4Generator.getAuthData().ecdsaSignature.signature =
             signAndGetRaw(concat(quoteV4Generator.getHeader().bytes(), quoteV4Generator.getTdReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV4Generator.buildTdxQuote();
+    const auto [view, quote] = quoteV4Generator.buildTdxQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};
@@ -874,7 +874,7 @@ TEST_F(VerifyQuoteIT, shouldReturnedStatusOKWhenVerifyQuoteV3WithSgxTcbInfoV3Suc
     quoteV3Generator.getAuthData().ecdsaSignature.signature =
     signAndGetRaw(concat(quoteV3Generator.getHeader().bytes(), quoteV3Generator.getEnclaveReport().bytes()), *pckCertKeyPtr);
 
-    auto quote = quoteV3Generator.buildQuote();
+    auto [view, quote] = quoteV3Generator.buildQuote();
     auto pckPem = certGenerator.x509ToString(cert.get());
     auto pckCrl = getValidCrl(interCert);
     auto tcbInfoBodyBytes = Bytes{};

--- a/Src/AttestationLibrary/test/UnitTests/BufferViewUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/BufferViewUT.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <Utils/BufferView.h>
+
+using namespace intel::sgx;
+
+TEST(BufferViewUT, size)
+{
+  // GIVEN
+  uint8_t buffer[] = {0x00, 0x01, 0x02};
+  dcap::BufferView view(buffer, std::size(buffer));
+ 
+  // WHEN
+  const size_t actualSize = view.size(); 
+
+  // THEN
+  EXPECT_EQ(3, actualSize);
+}
+
+TEST(BufferViewUT, cmp)
+{
+  // GIVEN
+  uint8_t buffer[] = {0x00, 0x01, 0x02};
+  const dcap::BufferView view(buffer, std::size(buffer));
+ 
+  // WHEN/THEN
+  for(size_t i = 0; i < std::size(buffer); ++i)
+    EXPECT_EQ(buffer[i], view[i]);  
+}
+
+TEST(BufferViewUT, iteratorCmp)
+{
+  // GIVEN
+  uint8_t buffer[] = {0x00, 0x01, 0x02};
+  const dcap::BufferView view(buffer, std::size(buffer));
+
+  // THEN
+  EXPECT_TRUE(std::equal(std::begin(buffer), std::end(buffer), view.cbegin(), view.cend())); 
+}
+
+TEST(BufferViewUT, distance)
+{
+  // GIVEN
+  uint8_t buffer[] = {0x00, 0x01, 0x02};
+  const dcap::BufferView view(buffer, std::size(buffer));
+
+  // THEN
+  EXPECT_EQ(std::size(buffer), std::distance(view.cbegin(), view.cend()));
+}
+
+TEST(BufferViewUT, next)
+{
+  // GIVEN
+  uint8_t buffer[] = {0x00, 0x01, 0x02, 0x03};
+  const dcap::BufferView view(buffer, std::size(buffer));
+
+  // WHEN
+  auto second = std::next(view.cbegin());
+
+  // THEN
+  EXPECT_EQ(buffer[1], *second);
+}
+
+TEST(BufferViewUT, advance)
+{
+  // GIVEN
+  uint8_t buffer[] = {0x00, 0x01, 0x02, 0x03};
+  const dcap::BufferView view(buffer, std::size(buffer));
+
+  // WHEN
+  auto position = std::next(view.cbegin());
+  std::advance(position, 2);
+
+  // THEN
+  EXPECT_EQ(buffer[3], *position);
+}
+

--- a/Src/AttestationLibrary/test/UnitTests/BufferViewUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/BufferViewUT.cpp
@@ -32,6 +32,8 @@
 #include <gtest/gtest.h>
 #include <Utils/BufferView.h>
 
+#include <QuoteUtils.h>
+
 using namespace intel::sgx;
 
 TEST(BufferViewUT, size)
@@ -105,3 +107,14 @@ TEST(BufferViewUT, advance)
   EXPECT_EQ(buffer[3], *position);
 }
 
+TEST(BufferViewUT, checkBufferViewGeneration)
+{
+  // GIVEN
+  const std::vector<uint8_t> pckData{'p', 'c', 'k', 'd', 'a', 't', 'a'};
+
+  // WHEN
+  const auto bufferView = dcap::test::getView(pckData);
+
+  // WHEN
+  ASSERT_TRUE( std::equal(pckData.begin(), pckData.end(), bufferView.cbegin(), bufferView.cend()) );
+}

--- a/Src/AttestationLibrary/test/UnitTests/GetQECertificationDataSizeUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/GetQECertificationDataSizeUT.cpp
@@ -80,7 +80,7 @@ TEST_F(GetQECertificationDataSizeTests, positiveValidParametersShouldReturnOkSta
     generator.withCertificationData(2, pckData)
              .withAuthDataSize((uint32_t) (generator.getAuthSize() + pckData.size()));
 
-    auto quote = generator.buildQuote();
+    auto [view, quote] = generator.buildQuote();
 
     // WHEN
     const auto status = sgxAttestationGetQECertificationDataSize(quote.data(), (uint32_t) quote.size(), &qeCertificationDataSize);
@@ -97,7 +97,8 @@ TEST_F(GetQECertificationDataSizeTests, positiveEmptycertificationDataShouldRetu
     const Bytes pckData; // empty
     generator.withCertificationData(2, pckData)
              .withAuthDataSize((uint32_t) (generator.getAuthSize() + pckData.size()));
-    const auto quote = generator.buildQuote();
+
+    const auto [view, quote] = generator.buildQuote();
 
     // WHEN
     const auto status = sgxAttestationGetQECertificationDataSize(quote.data(), (uint32_t) quote.size(), &qeCertificationDataSize);

--- a/Src/AttestationLibrary/test/UnitTests/GetQECertificationDataUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/GetQECertificationDataUT.cpp
@@ -46,12 +46,13 @@ struct GetQECertificationDataTests : public Test
     uint32_t placeholderSize = 0;
     uint16_t placeholderQeCertificationDataType = test::constants::PCK_ID_PLAIN_PPID;
 
-    Bytes prepareQuoteWithCertData(const uint16_t type, const Bytes &data) const
+    test::TestQuote prepareQuoteWithCertData(const uint16_t type, const Bytes &data) const
     {
         test::QuoteV3Generator generator;
         const Bytes pckData{'p', 'c', 'k', 'd', 'a', 't', 'a'};
         generator.withCertificationData(type, data)
                  .withAuthDataSize((uint32_t)(generator.getAuthSize() + data.size()));
+
         return generator.buildQuote();
     }
 };
@@ -99,7 +100,7 @@ TEST_F(GetQECertificationDataTests, invalidQuoteFormatShouldReturnUnsupportedQuo
 TEST_F(GetQECertificationDataTests, qeCertificationDataSizeAsParameterDiffersFromQuoteDataShouldReturnInvalidQeCertificationDataSizeStatus)
 {
     // GIVEN
-    auto quote = prepareQuoteWithCertData(test::constants::PCK_ID_PLAIN_PPID, {'p', 'c', 'k', 'd', 'a', 't', 'a'});
+    auto [view, quote] = prepareQuoteWithCertData(test::constants::PCK_ID_PLAIN_PPID, {'p', 'c', 'k', 'd', 'a', 't', 'a'});
 
     // WHEN/THEN
     ASSERT_EQ(STATUS_INVALID_QE_CERTIFICATION_DATA_SIZE,
@@ -111,7 +112,7 @@ TEST_F(GetQECertificationDataTests, positiveEmptycertificationDataShouldReturnOk
 {
     // GIVEN
     const auto expectedQeCertType = test::constants::PCK_ID_PLAIN_PPID;
-    const auto quote = prepareQuoteWithCertData(expectedQeCertType, {});
+    const auto [view, quote] = prepareQuoteWithCertData(expectedQeCertType, {});
     uint32_t qeCertificationDataSize = 0;
 
     const uint32_t CERT_DATA_BUFFER_SIZE = 1024;
@@ -141,7 +142,7 @@ TEST_P(GetQECertificationDataPositiveTests, validcertificationDataShouldReturnOk
     // GIVEN
     const auto expectedQeCertType = GetParam();
     const auto expectedcertificationData = Bytes{'p', 'c', 'k', 'd', 'a', 't', 'a'};
-    const auto quote = prepareQuoteWithCertData(expectedQeCertType, expectedcertificationData);
+    const auto [view, quote] = prepareQuoteWithCertData(expectedQeCertType, expectedcertificationData);
 
     std::vector<uint8_t> qeCertificationDataBuffer(expectedcertificationData.size(), 0x00);  // allocate an empty vector, it should be unchanged
     uint16_t qeCertificationDataType = 0;

--- a/Src/AttestationLibrary/test/UnitTests/QuoteV3ParsingUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/QuoteV3ParsingUT.cpp
@@ -110,8 +110,8 @@ bool operator==(const dcap::test::QuoteV3Generator::QuoteAuthData& testAuth, con
 
 TEST(QuoteV3ParsingUT, shouldNotDeserializeIfQuoteTooShort)
 {
-    const auto quote = dcap::test::QuoteV3Generator{}.buildQuote();
-    EXPECT_FALSE(dcap::Quote{}.parse(std::vector<uint8_t>(quote.cbegin(), quote.cend()-2)));
+    const auto [view, quote] = dcap::test::QuoteV3Generator{}.buildQuote();
+    EXPECT_FALSE(dcap::Quote{}.parse(intel::sgx::dcap::BufferView(quote.data(), quote.size()-2)));
 }
 
 TEST(QuoteV3ParsingUT, shouldParseStubQuoteWithMinimumSize)
@@ -128,8 +128,9 @@ TEST(QuoteV3ParsingUT, shouldParseStubQuoteWithMinimumSize)
         .withAuthData(auth);
 
     // WHEN
+    const auto [view, quoteBytes] = gen.buildQuote();
     dcap::Quote quote;
-    EXPECT_TRUE(quote.parse(gen.buildQuote()));
+    EXPECT_TRUE(quote.parse(view));
 
     // THEN
     EXPECT_TRUE(header == quote.getHeader());
@@ -144,12 +145,13 @@ TEST(QuoteV3ParsingUT, shouldParseEmptyHeader)
     const auto headerBytes = testHeader.bytes();
 
     // WHEN
-    auto from = headerBytes.begin();
+    const auto view = dcap::test::getView(headerBytes);
+    auto from = view.cbegin();
     dcap::Header header;
-    header.insert(from, headerBytes.cend());
+    header.insert(from, view.cend());
 
     // THEN
-    ASSERT_TRUE(from == headerBytes.cend());
+    ASSERT_TRUE(from == view.cend());
     EXPECT_TRUE(testHeader == header);
 }
 
@@ -167,11 +169,11 @@ TEST(QuoteV3ParsingUT, shouldParseAndValidateQuoteHeader)
     dcap::test::QuoteV3Generator generator;
 
     generator.withHeader(testHeader);
-    const auto quote = generator.buildQuote();
+    const auto [view, quote] = generator.buildQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(view));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -191,11 +193,11 @@ TEST(QuoteV3ParsingUT, shouldParseAndNotValidateBecauseAttestationKeyTypeNotSupp
     dcap::test::QuoteV3Generator generator;
 
     generator.withHeader(testHeader);
-    const auto quote = generator.buildQuote();
+    const auto [view, quote] = generator.buildQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(view));
     ASSERT_FALSE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -215,11 +217,11 @@ TEST(QuoteV3ParsingUT, shouldParseAndNotValidateBecauseQeVendorIdNotSupported)
     dcap::test::QuoteV3Generator generator;
 
     generator.withHeader(testHeader);
-    const auto quote = generator.buildQuote();
+    const auto [view, quote] = generator.buildQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(view));
     ASSERT_FALSE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -239,11 +241,11 @@ TEST(QuoteV3ParsingUT, shouldParseButNotValidateBecauseVersionNotSupported)
     dcap::test::QuoteV3Generator generator;
 
     generator.withHeader(testHeader);
-    const auto quote = generator.buildQuote();
+    const auto [view, quote] = generator.buildQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(view));
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
     ASSERT_FALSE(quoteObj.validate());
@@ -263,11 +265,11 @@ TEST(QuoteV3ParsingUT, shouldNotParseBecauseTeeTypeNotSupported)
     dcap::test::QuoteV3Generator generator;
 
     generator.withHeader(testHeader);
-    const auto quote = generator.buildQuote();
+    const auto [view, quote] = generator.buildQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldNotParseQuoteTDXHeaderWithEnclaveReport)
@@ -284,11 +286,11 @@ TEST(QuoteV3ParsingUT, shouldNotParseQuoteTDXHeaderWithEnclaveReport)
     dcap::test::QuoteV3Generator generator;
 
     generator.withHeader(testHeader);
-    const auto quote = generator.buildQuote();
+    const auto [view, quote] = generator.buildQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldParseEnclaveReport)
@@ -296,11 +298,12 @@ TEST(QuoteV3ParsingUT, shouldParseEnclaveReport)
     const dcap::test::QuoteV3Generator::EnclaveReport testReport{};
     const auto bytes = testReport.bytes();
 
-    auto from = bytes.begin();
+    const auto view = dcap::test::getView(bytes);
+    auto from = view.cbegin();
     dcap::EnclaveReport report{};
-    report.insert(from, bytes.cend());
+    report.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     ASSERT_TRUE(testReport == report);
     ASSERT_THAT(report.rawBlob(), ::testing::ElementsAreArray(bytes));
 }
@@ -316,10 +319,11 @@ TEST(QuoteV3ParsingUT, shouldParseQuoteBody)
     dcap::test::QuoteV3Generator gen{};
     gen.withEnclaveReport(testreport);
 
-    dcap::Quote quote;
+    const auto [view, quote] = gen.buildQuote();
+    dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quote.parse(gen.buildQuote()));
-    EXPECT_TRUE(testreport == quote.getEnclaveReport());
+    ASSERT_TRUE(quoteObj.parse(view));
+    EXPECT_TRUE(testreport == quoteObj.getEnclaveReport());
 }
 
 TEST(QuoteV3ParsingUT, shouldParseQeAuthData)
@@ -327,11 +331,12 @@ TEST(QuoteV3ParsingUT, shouldParseQeAuthData)
     dcap::test::QuoteV3Generator::QeAuthData testAuth{5, {1, 2, 3, 4, 5}};
     const auto bytes = testAuth.bytes();
 
-    auto from = bytes.begin();
+    const auto view = dcap::test::getView(bytes);
+    auto from = view.cbegin();
     dcap::QeAuthData auth;
-    auth.insert(from, bytes.cend());
+    auth.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     EXPECT_EQ(5, auth.parsedDataSize);
     EXPECT_EQ(5, auth.data.size());
     EXPECT_EQ(testAuth.data, auth.data);
@@ -342,24 +347,27 @@ TEST(QuoteV3ParsingUT, shouldParseQeAuthWithShorterDataButPointerShouldNotBeMove
     dcap::test::QuoteV3Generator::QeAuthData testAuth{5, {1, 2, 3, 4}};
     const auto bytes = testAuth.bytes();
 
-    auto from = bytes.begin();
+    const auto view = dcap::test::getView(bytes);
+    auto from = view.cbegin();
     dcap::QeAuthData auth;
-    auth.insert(from, bytes.cend());
+    auth.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.begin());
+    ASSERT_TRUE(from == view.cbegin());
     EXPECT_EQ(5, auth.parsedDataSize);
     EXPECT_EQ(0, auth.data.size());
 }
 
 TEST(QuoteV3ParsingUT, shouldNotParseTooShortQuote)
 {
-    auto quoteBytes = dcap::test::QuoteV3Generator{}.buildQuote();
+    const auto [view, quoteBytes] = dcap::test::QuoteV3Generator{}.buildQuote();
     std::vector<uint8_t> tooShortQuote;
     tooShortQuote.reserve(quoteBytes.size() - 1);
     std::copy(quoteBytes.begin(), quoteBytes.end() - 1, std::back_inserter(tooShortQuote));
 
+    const auto tooShortView = dcap::test::getView(tooShortQuote);
+
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(tooShortQuote));
+    EXPECT_FALSE(quote.parse(tooShortView));
 }
 
 TEST(QuoteV3ParsingUT, shouldNotParseIfAuthDataSizeBiggerThanRemaingData)
@@ -367,8 +375,10 @@ TEST(QuoteV3ParsingUT, shouldNotParseIfAuthDataSizeBiggerThanRemaingData)
     dcap::test::QuoteV3Generator gen;
     ++gen.getAuthSize();
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildQuote()));
+    EXPECT_FALSE(quote.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldNotParseIfAuthDataSizeSmallerThanRemaingData)
@@ -376,8 +386,9 @@ TEST(QuoteV3ParsingUT, shouldNotParseIfAuthDataSizeSmallerThanRemaingData)
     dcap::test::QuoteV3Generator gen;
     --gen.getAuthSize();
 
+    const auto [view, quoteBytes] = gen.buildQuote();
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildQuote()));
+    EXPECT_FALSE(quote.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldParseCustomQeAuth)
@@ -391,8 +402,10 @@ TEST(QuoteV3ParsingUT, shouldParseCustomQeAuth)
     gen.withQeAuthData(qeAuthData);
     gen.getAuthSize() +=  3; //QeAuthData::size byte len is const and already taken into account when creating default gen object
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildQuote()));
+    ASSERT_TRUE(quote.parse(view));
     EXPECT_TRUE(qeAuthData == quote.getAuthDataV3().qeAuthData);
 }
 
@@ -407,8 +420,10 @@ TEST(QuoteV3ParsingUT, shouldNotParseWhenQuoteAuthDataSizeBiggerThanRemainingBuf
     gen.withQeAuthData(qeAuthData);
     gen.getAuthSize() += 3;
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildQuote()));
+    EXPECT_FALSE(quote.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSizeAreTooMuch)
@@ -422,9 +437,10 @@ TEST(QuoteV3ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSize
     gen.withQeAuthData(qeAuthData);
     gen.getAuthSize() += 3;
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-	auto builtQuote = gen.buildQuote();
-    EXPECT_FALSE(quote.parse(builtQuote));
+    EXPECT_FALSE(quote.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldParsecertificationData)
@@ -439,8 +455,10 @@ TEST(QuoteV3ParsingUT, shouldParsecertificationData)
     gen.withcertificationData(qeCert);
     gen.getAuthSize() += 4;
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildQuote()));
+    ASSERT_TRUE(quote.parse(view));
     EXPECT_EQ(qeCert.keyData, quote.getAuthDataV3().certificationData.data);
     EXPECT_EQ(qeCert.size, quote.getAuthDataV3().certificationData.parsedDataSize);
     EXPECT_EQ(qeCert.keyDataType, quote.getAuthDataV3().certificationData.type);
@@ -458,8 +476,10 @@ TEST(QuoteV3ParsingUT, shouldParseWhenAuthDataSizeMatchButcertificationDataParse
     gen.withcertificationData(qeCert);
     gen.getAuthSize() += 4;
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildQuote()));
+    ASSERT_TRUE(quote.parse(view));
     ASSERT_TRUE(quote.validate());
 }
 
@@ -475,8 +495,10 @@ TEST(QuoteV3ParsingUT, shouldNotParseWhenAuthDataSizeMatchButcertificationDataPa
     gen.withcertificationData(qeCert);
     gen.getAuthSize() += 4;
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-    ASSERT_FALSE(quote.parse(gen.buildQuote()));
+    ASSERT_FALSE(quote.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldParseQeAuthAndQeCert)
@@ -497,8 +519,10 @@ TEST(QuoteV3ParsingUT, shouldParseQeAuthAndQeCert)
     gen.withQeAuthData(qeAuthData);
     gen.getAuthSize() += 3;
 
+    const auto [view, quoteBytes] = gen.buildQuote();
+
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildQuote()));
+    ASSERT_TRUE(quote.parse(view));
 }
 
 TEST(QuoteV3ParsingUT, shouldNotParsecertificationDataWithUnsupportedType)
@@ -514,6 +538,7 @@ TEST(QuoteV3ParsingUT, shouldNotParsecertificationDataWithUnsupportedType)
     gen.getAuthSize() += 4;
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildQuote()));
+    const auto [view, quoteBytes] = gen.buildQuote();
+    ASSERT_TRUE(quote.parse(view));
     ASSERT_FALSE(quote.validate());
 }

--- a/Src/AttestationLibrary/test/UnitTests/QuoteV3VerifierUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/QuoteV3VerifierUT.cpp
@@ -33,8 +33,6 @@
 #include <Verifiers/QuoteVerifier.h>
 #include <PckParser/FormatException.h>
 
-#include <utility>
-
 #include "Mocks/CertCrlStoresMocks.h"
 #include "Mocks/EnclaveIdentityMock.h"
 #include "Mocks/EnclaveReportVerifierMock.h"
@@ -56,7 +54,7 @@ namespace {
         int32_t ret = 0;
         ret |= static_cast<int32_t>(rightMostByte);
         ret |= (static_cast<int32_t>(leftMostByte) << 8) & 0xff00;
-        return (uint16_t) ret;
+        return static_cast<uint16_t>(ret);
     }
 
     std::array<uint8_t,64> signAndGetRaw(const std::vector<uint8_t>& data, EVP_PKEY& key)
@@ -198,36 +196,36 @@ TEST_F(QuoteV3VerifierUT, shouldReturnStatusTcbInfoMismatchWhenPceIdDoesNotMatch
 
 TEST_F(QuoteV3VerifierUT, shouldReturnStatusInvalidPckCrlWhenPeriodAndIssuerIsInvalid)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [view, quoteBin] = gen.buildQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::ROOT_CA_CRL_ISSUER));
 
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(view));
     EXPECT_EQ(STATUS_INVALID_PCK_CRL, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnStatusInvalidPckCrlWhenCrlIssuerIsDifferentThanPck)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::PCK_PLATFORM_CRL_ISSUER));
     EXPECT_CALL(pck, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::PROCESSOR_CA_SUBJECT));
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CRL, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnStatusPckRevoked)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, isRevoked(testing::_)).WillOnce(testing::Return(true));
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_PCK_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -235,21 +233,21 @@ TEST_F(QuoteV3VerifierUT, shouldReturnStatusInvalidQeFormat)
 {
     dcap::Quote quote;
     gen.getAuthData().ecdsaAttestationKey.publicKey = std::array<uint8_t, 64>{};
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QE_REPORT_DATA, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldVerifySgxCorrectly)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     tcbs.insert(tcbs.begin(), dcap::parser::json::TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -257,10 +255,10 @@ TEST_F(QuoteV3VerifierUT, shouldReturnInvalidPCKCert)
 {
     const auto emptySubject = dcap::parser::x509::DistinguishedName("", "", "", "", "", "");
     ON_CALL(pck, getSubject()).WillByDefault(testing::ReturnRef(emptySubject));
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CERT, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -278,13 +276,13 @@ TEST_P(QuoteV3VerifierUTPckTypesParametrized, shouldReturnStatusOkEvenWhenPpidIs
     certificationData.keyData = concat(ppid, concat(cpusvn, pcesvn));
     certificationData.size = static_cast<uint16_t>(certificationData.keyData.size());
 
-    const auto quoteBin = gen.withcertificationData(certificationData).buildQuote();
+    const auto [quoteView, quoteBin] = gen.withcertificationData(certificationData).buildQuote();
 
     tcbs.insert(tcbs.begin(), dcap::parser::json::TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -299,38 +297,38 @@ INSTANTIATE_TEST_SUITE_P(PckIdTypesThatDoNotValidatecertificationData,
 TEST_F(QuoteV3VerifierUT, shouldReturnQuoteInvalidSignature)
 {
     gen.getAuthData().ecdsaSignature.signature[0] = (unsigned char) ~gen.getAuthData().ecdsaSignature.signature[0];
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QUOTE_SIGNATURE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnInvalidQeReportSignature)
 {
     gen.getAuthData().qeReportSignature.signature[0] = (unsigned char) ~gen.getAuthData().qeReportSignature.signature[0];
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QE_REPORT_SIGNATURE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnTcbRevokedOnLatestRevokedEqualPckTCB)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     tcbs.insert(tcbs.begin(), dcap::parser::json::TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "Revoked"});
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -343,13 +341,13 @@ TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConf
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConfigurationNeededForTcbInfoV2)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -363,13 +361,13 @@ TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConf
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnOutOfDateConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -383,13 +381,13 @@ TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnOutO
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_OUT_OF_DATE_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -406,7 +404,7 @@ TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationNeeded)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -414,7 +412,7 @@ TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationNeeded)
 
 TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationAndSwHardeningNeeded)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -431,13 +429,13 @@ TEST_F(QuoteV3VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationAndSwHarden
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_AND_SW_HARDENING_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnTcbNotSupportedWhenOnlyPceSvnIsHigher)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     const std::vector<uint8_t> higherPcesvn = {0xff, 0xff};
 
@@ -445,13 +443,13 @@ TEST_F(QuoteV3VerifierUT, shouldReturnTcbNotSupportedWhenOnlyPceSvnIsHigher)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_NOT_SUPPORTED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnTcbRevokedWhenOnlyCpuSvnIsLower)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -460,13 +458,13 @@ TEST_F(QuoteV3VerifierUT, shouldReturnTcbRevokedWhenOnlyCpuSvnIsLower)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnTcbRevokedWhenOnlyPcesvnIsLower)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     const std::vector<uint8_t> lowerPcesvn = {0x21, 0x12};
 
@@ -474,13 +472,13 @@ TEST_F(QuoteV3VerifierUT, shouldReturnTcbRevokedWhenOnlyPcesvnIsLower)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldNOTReturnTcbRevokedWhenRevokedPcesvnAndCpusvnAreLower)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -492,13 +490,13 @@ TEST_F(QuoteV3VerifierUT, shouldNOTReturnTcbRevokedWhenRevokedPcesvnAndCpusvnAre
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnSwHardeningNeeded)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -509,16 +507,16 @@ TEST_F(QuoteV3VerifierUT, shouldReturnSwHardeningNeeded)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_SW_HARDENING_NEEDED , dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV3VerifierUT, shouldReturnStatusNotSupportedWhenEnclaveReportVeriferIsIsvsvnNotSupported)
 {
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
     EXPECT_CALL(enclaveReportVerifier, verify(_, _)).WillOnce(Return(STATUS_SGX_ENCLAVE_REPORT_ISVSVN_NOT_SUPPORTED));
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_NOT_SUPPORTED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -534,9 +532,9 @@ struct QuoteV3VerifierUTQeIdentityStatusParametrized : public QuoteV3VerifierUT,
 TEST_P(QuoteV3VerifierUTQeIdentityStatusParametrized, testAllStatuses)
 {
     auto params = GetParam();
-    const auto quoteBin = gen.buildQuote();
+    const auto [quoteView, quoteBin] = gen.buildQuote();
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     tcbs.insert(tcbs.begin(), dcap::parser::json::TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     if (params.enclaveVerifierStatus == STATUS_OK)
     {

--- a/Src/AttestationLibrary/test/UnitTests/QuoteV4ParsingUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/QuoteV4ParsingUT.cpp
@@ -36,6 +36,8 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
 
+#include "QuoteUtils.h"
+
 using namespace intel::sgx;
 namespace{
 
@@ -119,8 +121,10 @@ struct QuoteV4ParsingUT: public testing::Test
 
 TEST_F(QuoteV4ParsingUT, shouldNotDeserializeIfQuoteTooShort)
 {
-    const auto quote = dcap::test::QuoteV4Generator{}.buildSgxQuote();
-    EXPECT_FALSE(dcap::Quote{}.parse(std::vector<uint8_t>(quote.cbegin(), quote.cend()-2)));
+    const auto [quoteView, quote] = dcap::test::QuoteV4Generator{}.buildSgxQuote();
+
+    dcap::BufferView subView(quote.data(), quote.size() - 2);
+    EXPECT_FALSE(dcap::Quote{}.parse(subView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldParseStubQuoteWithMinimumSize)
@@ -134,7 +138,7 @@ TEST_F(QuoteV4ParsingUT, shouldParseStubQuoteWithMinimumSize)
 
     // WHEN
     dcap::Quote quote;
-    EXPECT_TRUE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
 
     // THEN
     EXPECT_TRUE(header == quote.getHeader());
@@ -146,14 +150,15 @@ TEST_F(QuoteV4ParsingUT, shouldParseEmptyHeader)
      // GIVEN
     const dcap::test::QuoteV4Generator::QuoteHeader testHeader{};
     const auto headerBytes = testHeader.bytes();
+    const auto headerView = dcap::test::getView(headerBytes); 
 
     // WHEN
-    auto from = headerBytes.begin();
+    auto from = headerView.cbegin();
     dcap::Header header;
-    header.insert(from, headerBytes.cend());
+    header.insert(from, headerView.cend());
 
     // THEN
-    ASSERT_TRUE(from == headerBytes.cend());
+    ASSERT_TRUE(from == headerView.cend());
     EXPECT_TRUE(testHeader == header);
 }
 
@@ -167,11 +172,11 @@ TEST_F(QuoteV4ParsingUT, shouldParseAndValidateQuoteHeader)
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildSgxQuote();
+    const auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(sgxQuoteView));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -187,11 +192,11 @@ TEST_F(QuoteV4ParsingUT, shouldParseAndNotValidateBecauseAttestationKeyTypeNotSu
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildSgxQuote();
+    const auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(sgxQuoteView));
     ASSERT_FALSE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -209,11 +214,11 @@ TEST_F(QuoteV4ParsingUT, shouldParseAndNotValidateBecauseQeVendorIdNotSupported)
 
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildSgxQuote();
+    const auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(sgxQuoteView));
     ASSERT_FALSE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -230,11 +235,11 @@ TEST_F(QuoteV4ParsingUT, shouldParseButNotValidateBecauseVersionNotSupported)
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildSgxQuote();
+    const auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(sgxQuoteView));
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
     ASSERT_FALSE(quoteObj.validate());
@@ -250,11 +255,11 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseBecauseTeeTypeNotSupported)
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildSgxQuote();
+    const auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(sgxQuoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseQuoteTDXHeaderWithEnclaveReport)
@@ -267,11 +272,11 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseQuoteTDXHeaderWithEnclaveReport)
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildSgxQuote();
+    const auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(sgxQuoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseQuoteSGXHeaderWithTdReport)
@@ -284,11 +289,11 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseQuoteSGXHeaderWithTdReport)
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildTdxQuote();
+    const auto [view, quote] = gen.buildTdxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(view));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldParseAndValidateQuoteSGXHeader)
@@ -302,11 +307,11 @@ TEST_F(QuoteV4ParsingUT, shouldParseAndValidateQuoteSGXHeader)
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildSgxQuote();
+    const auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(sgxQuoteView));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -323,11 +328,11 @@ TEST_F(QuoteV4ParsingUT, shouldParseAndValidateQuoteTDXHeader)
     testHeader.userData = {};
 
     gen.withHeader(testHeader);
-    const auto quote = gen.buildTdxQuote();
+    const auto [quoteView, quote] = gen.buildTdxQuote();
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quoteView));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -337,12 +342,13 @@ TEST_F(QuoteV4ParsingUT, shouldParseEnclaveReport)
 {
     const dcap::test::QuoteV4Generator::EnclaveReport testReport{};
     const auto bytes = testReport.bytes();
+    const auto view = dcap::test::getView(bytes);
 
-    auto from = bytes.begin();
+    auto from = view.cbegin();
     dcap::EnclaveReport report{};
-    report.insert(from, bytes.cend());
+    report.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     ASSERT_TRUE(testReport == report);
     ASSERT_THAT(report.rawBlob(), ::testing::ElementsAreArray(bytes));
 }
@@ -352,11 +358,13 @@ TEST_F(QuoteV4ParsingUT, shouldParseTDReport)
     const dcap::test::QuoteV4Generator::TDReport testReport{};
     const auto bytes = testReport.bytes();
 
-    auto from = bytes.begin();
-    dcap::TDReport10 report{};
-    report.insert(from, bytes.cend());
+    const auto view = dcap::test::getView(bytes);
 
-    ASSERT_TRUE(from == bytes.cend());
+    auto from = view.cbegin();
+    dcap::TDReport10 report{};
+    report.insert(from, view.cend());
+
+    ASSERT_TRUE(from == view.cend());
     EXPECT_TRUE(testReport == report);
     ASSERT_THAT(report.rawBlob(), ::testing::ElementsAreArray(bytes));
 }
@@ -373,7 +381,7 @@ TEST_F(QuoteV4ParsingUT, shouldParseQuoteBody)
 
     dcap::Quote quote;
 
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     EXPECT_TRUE(testreport == quote.getEnclaveReport());
 }
 
@@ -381,12 +389,13 @@ TEST_F(QuoteV4ParsingUT, shouldParseQeAuthData)
 {
     dcap::test::QuoteV4Generator::QeAuthData testAuth{5, {1, 2, 3, 4, 5}};
     const auto bytes = testAuth.bytes();
+    const auto view = dcap::test::getView(bytes);
 
-    auto from = bytes.begin();
+    auto from = view.cbegin();
     dcap::QeAuthData auth;
-    auth.insert(from, bytes.cend());
+    auth.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     EXPECT_EQ(5, auth.parsedDataSize);
     EXPECT_EQ(5, auth.data.size());
     EXPECT_EQ(testAuth.data, auth.data);
@@ -396,25 +405,26 @@ TEST_F(QuoteV4ParsingUT, shouldParseQeAuthWithShorterDataButPointerShouldNotBeMo
 {
     dcap::test::QuoteV4Generator::QeAuthData testAuth{5, {1, 2, 3, 4}};
     const auto bytes = testAuth.bytes();
+    const auto view = dcap::test::getView(bytes);
 
-    auto from = bytes.begin();
+    auto from = view.cbegin();
     dcap::QeAuthData auth;
-    auth.insert(from, bytes.cend());
+    auth.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.begin());
+    ASSERT_TRUE(from == view.cbegin());
     EXPECT_EQ(5, auth.parsedDataSize);
     EXPECT_EQ(0, auth.data.size());
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseTooShortQuote)
 {
-    auto quoteBytes = dcap::test::QuoteV4Generator{}.buildSgxQuote();
-    std::vector<uint8_t> tooShortQuote;
-    tooShortQuote.reserve(quoteBytes.size() - 1);
-    std::copy(quoteBytes.begin(), quoteBytes.end() - 1, std::back_inserter(tooShortQuote));
+    auto [quoteView, quoteBytes] = dcap::test::QuoteV4Generator{}.buildSgxQuote();
+    std::vector<uint8_t> tooShortQuote(quoteBytes.begin(), quoteBytes.end() - 1);
+    
+    const auto tooShortView = dcap::test::getView(tooShortQuote);
 
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(tooShortQuote));
+    EXPECT_FALSE(quote.parse(tooShortView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseIfAuthDataSizeBiggerThanRemaingData)
@@ -422,7 +432,7 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseIfAuthDataSizeBiggerThanRemaingData)
     ++gen.getAuthSize();
 
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseIfAuthDataSizeSmallerThanRemainingData)
@@ -430,7 +440,7 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseIfAuthDataSizeSmallerThanRemainingData)
     --gen.getAuthSize();
 
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldParseCustomQeAuth)
@@ -446,7 +456,7 @@ TEST_F(QuoteV4ParsingUT, shouldParseCustomQeAuth)
     gen.getAuthData().authDataSize += 3; // qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     EXPECT_TRUE(certificationData == quote.getAuthDataV4().certificationData);
 }
 
@@ -463,7 +473,7 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSi
     gen.getAuthData().authDataSize += 3 + 1; // qeAuthData.size + 1
 
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSizeAreTooMuch)
@@ -479,8 +489,8 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSi
     gen.getAuthData().authDataSize += 3; // correct qeAuthData.size
 
     dcap::Quote quote;
-	auto builtQuote = gen.buildSgxQuote();
-    EXPECT_FALSE(quote.parse(builtQuote));
+	  auto [sgxQuoteView, sgxQuote] = gen.buildSgxQuote();
+    EXPECT_FALSE(quote.parse(sgxQuoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldParseCertificationData)
@@ -494,7 +504,7 @@ TEST_F(QuoteV4ParsingUT, shouldParseCertificationData)
     gen.getAuthData().authDataSize += 4; // certificationData.size
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     EXPECT_EQ(qeReportCertificationData.certificationData.keyData, quote.getCertificationData().data);
     EXPECT_EQ(qeReportCertificationData.certificationData.keyDataType, quote.getCertificationData().type);
     EXPECT_EQ(qeReportCertificationData.certificationData.size, quote.getCertificationData().parsedDataSize);
@@ -513,7 +523,7 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseWhenAuthDataSizeMatchButCertificationData
     gen.getAuthData().authDataSize += 4 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_FALSE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseWhenAuthDataSizeMatchButCertificationDataParsedSizeIsTooMuch)
@@ -529,7 +539,7 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseWhenAuthDataSizeMatchButCertificationData
     gen.getAuthData().authDataSize += 5 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_FALSE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotParseWhenAuthDataSizeMatchButQeAuthDataParsedSizeIsTooMuch)
@@ -545,7 +555,7 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseWhenAuthDataSizeMatchButQeAuthDataParsedS
     gen.getAuthData().authDataSize += 4 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_FALSE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldParseQeAuthAndQeCert)
@@ -561,7 +571,7 @@ TEST_F(QuoteV4ParsingUT, shouldParseQeAuthAndQeCert)
     gen.getAuthData().authDataSize += 4 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV4ParsingUT, shouldNotValidateQeAuthAndQeCertWithUnsupportedType)
@@ -573,7 +583,7 @@ TEST_F(QuoteV4ParsingUT, shouldNotValidateQeAuthAndQeCertWithUnsupportedType)
     gen.withCertificationData(certificationData);
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     ASSERT_FALSE(quote.validate());
 }
 
@@ -583,6 +593,6 @@ TEST_F(QuoteV4ParsingUT, shouldNotParseCertificationDataWithUnsupportedType)
     gen.withCertificationData(certificationData);
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     ASSERT_FALSE(quote.validate());
 }

--- a/Src/AttestationLibrary/test/UnitTests/QuoteV4VerifierUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/QuoteV4VerifierUT.cpp
@@ -33,7 +33,6 @@
 #include <Verifiers/QuoteVerifier.h>
 #include <PckParser/FormatException.h>
 
-#include <utility>
 #include <QuoteVerification/QuoteConstants.h>
 
 #include "Mocks/CertCrlStoresMocks.h"
@@ -43,7 +42,6 @@
 #include "DigestUtils.h"
 #include "QuoteV4Generator.h"
 #include "KeyHelpers.h"
-#include "Constants/QuoteTestConstants.h"
 #include "EcdsaSignatureGenerator.h"
 #include "CertVerification/X509Constants.h"
 
@@ -221,36 +219,36 @@ TEST_F(QuoteV4VerifierUT, shouldReturnStatusTcbInfoMismatchWhenPceIdDoesNotMatch
 
 TEST_F(QuoteV4VerifierUT, shouldReturnStatusInvalidPckCrlWhenPeriodAndIssuerIsInvalid)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::ROOT_CA_CRL_ISSUER));
 
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CRL, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnStatusInvalidPckCrlWhenCrlIssuerIsDifferentThanPck)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::PCK_PLATFORM_CRL_ISSUER));
     EXPECT_CALL(pck, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::PROCESSOR_CA_SUBJECT));
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CRL, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnStatusPckRevoked)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, isRevoked(testing::_)).WillOnce(testing::Return(true));
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_PCK_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -258,22 +256,22 @@ TEST_F(QuoteV4VerifierUT, shouldReturnStatusInvalidQeFormat)
 {
     dcap::Quote quote;
     gen.getAuthData().ecdsaAttestationKey.publicKey = std::array<uint8_t, 64>{};
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QE_REPORT_DATA, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldVerifySgxCorrectly)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     tcbs.insert(tcbs.begin(),
                 TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -288,7 +286,7 @@ TEST_F(QuoteV4VerifierUT, shouldVerifyTdxCorrectly)
     gen.withTDReport(tdReport);
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
@@ -297,7 +295,7 @@ TEST_F(QuoteV4VerifierUT, shouldVerifyTdxCorrectly)
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -313,13 +311,13 @@ TEST_F(QuoteV4VerifierUT, shouldReturnSatusTdxModuleMismatchWhenTdReportSeamAttr
     gen.withTDReport(tdReport);
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
     EXPECT_CALL(tcbInfoJson, getVersion()).WillRepeatedly(testing::Return(3));
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TDX_MODULE_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -330,7 +328,7 @@ TEST_F(QuoteV4VerifierUT, shouldReturnStatusQEIdentityMismatchWhenTdxQuoteAndEnc
     header.teeType = dcap::constants::TEE_TYPE_TDX;
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
@@ -338,7 +336,7 @@ TEST_F(QuoteV4VerifierUT, shouldReturnStatusQEIdentityMismatchWhenTdxQuoteAndEnc
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_QE_IDENTITY_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -354,13 +352,13 @@ TEST_F(QuoteV4VerifierUT, shouldReturnStatusTdxModuleMismatchWhenTdReportMrsigne
     gen.withTDReport(tdReport);
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
 
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
     EXPECT_CALL(tcbInfoJson, getVersion()).WillRepeatedly(testing::Return(3));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TDX_MODULE_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -376,13 +374,13 @@ TEST_F(QuoteV4VerifierUT, shouldReturnStatusTdxModuleMismatchWhenTdReportSeamAtt
     gen.withTDReport(tdReport);
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
 
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
     EXPECT_CALL(tcbInfoJson, getVersion()).WillRepeatedly(testing::Return(3));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TDX_MODULE_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -390,20 +388,20 @@ TEST_F(QuoteV4VerifierUT, shouldReturnInvalidPCKCert)
 {
     const auto emptySubject = dcap::parser::x509::DistinguishedName("", "", "", "", "", "");
     ON_CALL(pck, getSubject()).WillByDefault(testing::ReturnRef(emptySubject));
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CERT, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnQuoteInvalidSignature)
 {
     gen.getAuthData().ecdsaSignature.signature[0] = (unsigned char) ~gen.getAuthData().ecdsaSignature.signature[0];
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QUOTE_SIGNATURE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -411,28 +409,28 @@ TEST_F(QuoteV4VerifierUT, shouldReturnInvalidQeReportSignature)
 {
     qeReportCertificationData.qeReportSignature.signature[0] = (unsigned char) ~qeReportCertificationData.qeReportSignature.signature[0];
     certificationData.keyData = qeReportCertificationData.bytes();
-    const auto quoteBin = gen.withCertificationData(certificationData).buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.withCertificationData(certificationData).buildSgxQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QE_REPORT_SIGNATURE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnTcbRevokedOnLatestRevokedEqualPckTCB)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "Revoked"});
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -445,13 +443,13 @@ TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConf
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConfigurationNeededForTcbInfoV2)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -465,13 +463,13 @@ TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConf
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnOutOfDateConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -485,13 +483,13 @@ TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnOutO
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_OUT_OF_DATE_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -508,13 +506,13 @@ TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationNeeded)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationAndSwHardeningNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -531,13 +529,13 @@ TEST_F(QuoteV4VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationAndSwHarden
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_AND_SW_HARDENING_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnTcbNotSupportedWhenOnlyPceSvnIsHigher)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     const std::vector<uint8_t> higherPcesvn = {0xff, 0xff};
 
@@ -545,13 +543,13 @@ TEST_F(QuoteV4VerifierUT, shouldReturnTcbNotSupportedWhenOnlyPceSvnIsHigher)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_NOT_SUPPORTED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnTcbRevokedWhenOnlyCpuSvnIsLower)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -560,13 +558,13 @@ TEST_F(QuoteV4VerifierUT, shouldReturnTcbRevokedWhenOnlyCpuSvnIsLower)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnTcbRevokedWhenOnlyPcesvnIsLower)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     const std::vector<uint8_t> lowerPcesvn = {0x21, 0x12};
 
@@ -574,13 +572,13 @@ TEST_F(QuoteV4VerifierUT, shouldReturnTcbRevokedWhenOnlyPcesvnIsLower)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldNOTReturnTcbRevokedWhenRevokedPcesvnAndCpusvnAreLower)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -592,13 +590,13 @@ TEST_F(QuoteV4VerifierUT, shouldNOTReturnTcbRevokedWhenRevokedPcesvnAndCpusvnAre
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV4VerifierUT, shouldReturnSwHardeningNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -609,7 +607,7 @@ TEST_F(QuoteV4VerifierUT, shouldReturnSwHardeningNeeded)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_SW_HARDENING_NEEDED , dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -625,9 +623,9 @@ struct QuoteV4VerifierUTQeIdentityStatusParametrized : public QuoteV4VerifierUT,
 TEST_P(QuoteV4VerifierUTQeIdentityStatusParametrized, testAllStatuses)
 {
     auto params = GetParam();
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     tcbs.insert(tcbs.begin(), TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     if (params.enclaveVerifierStatus == STATUS_OK)
     {
@@ -650,7 +648,7 @@ TEST_F(QuoteV4VerifierUT, shouldBackoffToLowerLevelBecauseTdReportTeeSvnIsOutOfD
     gen.withTDReport(tdReport);
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
 
     tcbs.insert(TcbLevel{"TDX", sgxTcbComponents, std::vector<TcbComponent>(16, TcbComponent(0xF0)), toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     tcbs.insert(TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "OutOfDate"});
@@ -661,7 +659,7 @@ TEST_F(QuoteV4VerifierUT, shouldBackoffToLowerLevelBecauseTdReportTeeSvnIsOutOfD
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_OUT_OF_DATE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -676,7 +674,7 @@ TEST_F(QuoteV4VerifierUT, shouldBackoffToLowerLevelBecauseNoAllSvnsAreHigher)
     gen.withTDReport(tdReport);
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
     std::vector<TcbComponent> tdxComponents = {0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
     tcbs.insert(TcbLevel{"TDX", sgxTcbComponents, tdxComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
@@ -688,7 +686,7 @@ TEST_F(QuoteV4VerifierUT, shouldBackoffToLowerLevelBecauseNoAllSvnsAreHigher)
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_OUT_OF_DATE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -703,7 +701,7 @@ TEST_F(QuoteV4VerifierUT, shouldReturnTcbNotSupportedIfNotMatchingTcbLevelIsFoun
     gen.withTDReport(tdReport);
     gen.withHeader(header);
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(concat(gen.getHeader().bytes(), gen.getTdReport().bytes()), *privKey);
-    const auto quoteBin = gen.buildTdxQuote();
+    const auto [quoteView, quoteBin] = gen.buildTdxQuote();
 
     tcbs.insert(TcbLevel{"TDX", sgxTcbComponents, std::vector<TcbComponent>(16, TcbComponent(0xF0)), toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     tcbs.insert(TcbLevel{"TDX", sgxTcbComponents, std::vector<TcbComponent>(16, TcbComponent(0x60)), toUint16(pcesvn[1], pcesvn[0]), "OutOfDate"});
@@ -714,7 +712,7 @@ TEST_F(QuoteV4VerifierUT, shouldReturnTcbNotSupportedIfNotMatchingTcbLevelIsFoun
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_NOT_SUPPORTED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 

--- a/Src/AttestationLibrary/test/UnitTests/QuoteV5ParsingUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/QuoteV5ParsingUT.cpp
@@ -30,7 +30,9 @@
  */
 
 
+#include "QuoteUtils.h"
 #include "QuoteV5Generator.h"
+#include "Utils/BufferView.h"
 #include <QuoteVerification/Quote.h>
 
 #include <gtest/gtest.h>
@@ -120,7 +122,8 @@ struct QuoteV5ParsingUT: public testing::Test
 TEST_F(QuoteV5ParsingUT, shouldNotDeserializeIfQuoteTooShort)
 {
     const auto quote = dcap::test::QuoteV5Generator{}.buildSgxQuote();
-    EXPECT_FALSE(dcap::Quote{}.parse(std::vector<uint8_t>(quote.cbegin(), quote.cend()-2)));
+    const dcap::BufferView testView(quote.quoteView.cbegin(), quote.quoteView.size() - 2);
+    EXPECT_FALSE(dcap::Quote{}.parse(testView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldParseStubQuoteWithMinimumSize)
@@ -134,7 +137,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseStubQuoteWithMinimumSize)
 
     // WHEN
     dcap::Quote quote;
-    EXPECT_TRUE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
 
     // THEN
     EXPECT_TRUE(header == quote.getHeader());
@@ -146,14 +149,14 @@ TEST_F(QuoteV5ParsingUT, shouldParseEmptyHeader)
      // GIVEN
     const dcap::test::QuoteV5Generator::QuoteHeader testHeader{};
     const auto headerBytes = testHeader.bytes();
-
+    const auto headerView = dcap::test::getView(headerBytes);
     // WHEN
-    auto from = headerBytes.begin();
+    auto from = headerView.cbegin();
     dcap::Header header;
-    header.insert(from, headerBytes.cend());
+    header.insert(from, headerView.cend());
 
     // THEN
-    ASSERT_TRUE(from == headerBytes.cend());
+    ASSERT_TRUE(from == headerView.cend());
     EXPECT_TRUE(testHeader == header);
 }
 
@@ -171,7 +174,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseAndValidateQuoteHeader)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -191,7 +194,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseAndNotValidateBecauseAttestationKeyTypeNotSu
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_FALSE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -213,7 +216,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseAndNotValidateBecauseQeVendorIdNotSupported)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_FALSE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -234,7 +237,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseButNotValidateBecauseVersionNotSupported)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
     ASSERT_FALSE(quoteObj.validate());
@@ -253,7 +256,7 @@ TEST_F(QuoteV5ParsingUT, shoulNotValidateBecauseTeeTypeNotSupported)
     const auto quote = gen.buildSgxQuote();
 
     dcap::Quote quoteObj;
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_FALSE(quoteObj.validate());
 }
 
@@ -271,7 +274,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotValidateQuoteTDXHeaderWithEnclaveReport)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_FALSE(quoteObj.validate());
 }
 
@@ -290,7 +293,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotValdiateQuoteSGXHeaderWithTdReport)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_FALSE(quoteObj.validate());
 }
 
@@ -309,7 +312,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseAndValidateQuoteSGXQuote)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -331,7 +334,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseAndValidateQuoteTDX10Quote)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -353,7 +356,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseAndValidateQuoteTDX15Header)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_TRUE(quoteObj.validate());
 
     EXPECT_TRUE(testHeader == quoteObj.getHeader());
@@ -374,7 +377,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotValdiateQuoteWithUnsupportedVersion)
 
     dcap::Quote quoteObj;
 
-    ASSERT_TRUE(quoteObj.parse(quote));
+    ASSERT_TRUE(quoteObj.parse(quote.quoteView));
     ASSERT_FALSE(quoteObj.validate());
 }
 
@@ -385,7 +388,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseQuoteWithUnsupportedBodyType)
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(quote.quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseSgxQuoteWithInvalidBodySize)
@@ -395,7 +398,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseSgxQuoteWithInvalidBodySize)
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(quote.quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseTdx10QuoteWithInvalidBodySize)
@@ -405,7 +408,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseTdx10QuoteWithInvalidBodySize)
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(quote.quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseTdx15QuoteWithInvalidBodySize)
@@ -415,19 +418,20 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseTdx15QuoteWithInvalidBodySize)
 
     dcap::Quote quoteObj;
 
-    ASSERT_FALSE(quoteObj.parse(quote));
+    ASSERT_FALSE(quoteObj.parse(quote.quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldParseEnclaveReport)
 {
     const dcap::test::QuoteV5Generator::EnclaveReport testReport{};
     const auto bytes = testReport.bytes();
+    const auto view = dcap::test::getView(bytes);
 
-    auto from = bytes.begin();
+    auto from = view.cbegin();
     dcap::EnclaveReport report{};
-    report.insert(from, bytes.cend());
+    report.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     ASSERT_TRUE(testReport == report);
     ASSERT_THAT(report.rawBlob(), ::testing::ElementsAreArray(bytes));
 }
@@ -436,12 +440,13 @@ TEST_F(QuoteV5ParsingUT, shouldParseTDReport10)
 {
     const dcap::test::QuoteV5Generator::TDReport10 testReport{};
     const auto bytes = testReport.bytes();
+    const auto view = dcap::test::getView(bytes);
 
-    auto from = bytes.begin();
+    auto from = view.cbegin();
     dcap::TDReport10 report{};
-    report.insert(from, bytes.cend());
+    report.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     EXPECT_TRUE(testReport == report);
     ASSERT_THAT(report.rawBlob(), ::testing::ElementsAreArray(bytes));
 }
@@ -450,12 +455,13 @@ TEST_F(QuoteV5ParsingUT, shouldParseTDReport15)
 {
     const dcap::test::QuoteV5Generator::TDReport15 testReport{};
     const auto bytes = testReport.bytes();
-
-    auto from = bytes.begin();
+    const auto view = dcap::test::getView(bytes);
+    
+    auto from = view.cbegin();
     dcap::TDReport15 report{};
-    report.insert(from, bytes.cend());
+    report.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     EXPECT_TRUE(testReport == report);
     ASSERT_THAT(report.rawBlob(), ::testing::ElementsAreArray(bytes));
 }
@@ -472,7 +478,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseQuoteBody)
 
     dcap::Quote quote;
 
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     EXPECT_TRUE(testreport == quote.getEnclaveReport());
 }
 
@@ -480,12 +486,13 @@ TEST_F(QuoteV5ParsingUT, shouldParseQeAuthData)
 {
     dcap::test::QuoteV5Generator::QeAuthData testAuth{5, {1, 2, 3, 4, 5}};
     const auto bytes = testAuth.bytes();
+    const auto view = dcap::test::getView(bytes);
 
-    auto from = bytes.begin();
+    auto from = view.cbegin();
     dcap::QeAuthData auth;
-    auth.insert(from, bytes.cend());
+    auth.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.cend());
+    ASSERT_TRUE(from == view.cend());
     EXPECT_EQ(5, auth.parsedDataSize);
     EXPECT_EQ(5, auth.data.size());
     EXPECT_EQ(testAuth.data, auth.data);
@@ -495,22 +502,21 @@ TEST_F(QuoteV5ParsingUT, shouldParseQeAuthWithShorterDataButPointerShouldNotBeMo
 {
     dcap::test::QuoteV5Generator::QeAuthData testAuth{5, {1, 2, 3, 4}};
     const auto bytes = testAuth.bytes();
+    const auto view = dcap::test::getView(bytes);
 
-    auto from = bytes.begin();
+    auto from = view.cbegin();
     dcap::QeAuthData auth;
-    auth.insert(from, bytes.cend());
+    auth.insert(from, view.cend());
 
-    ASSERT_TRUE(from == bytes.begin());
+    ASSERT_TRUE(from == view.cbegin());
     EXPECT_EQ(5, auth.parsedDataSize);
     EXPECT_EQ(0, auth.data.size());
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseTooShortQuote)
 {
-    auto quoteBytes = dcap::test::QuoteV5Generator{}.buildSgxQuote();
-    std::vector<uint8_t> tooShortQuote;
-    tooShortQuote.reserve(quoteBytes.size() - 1);
-    std::copy(quoteBytes.begin(), quoteBytes.end() - 1, std::back_inserter(tooShortQuote));
+    auto [quoteView, quoteBytes] = dcap::test::QuoteV5Generator{}.buildSgxQuote();
+    const dcap::BufferView tooShortQuote(quoteView.cbegin(), quoteView.size() - 1);
 
     dcap::Quote quote;
     EXPECT_FALSE(quote.parse(tooShortQuote));
@@ -521,7 +527,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseIfAuthDataSizeBiggerThanRemaingData)
     ++gen.getAuthSize();
 
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseIfAuthDataSizeSmallerThanRemainingData)
@@ -529,7 +535,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseIfAuthDataSizeSmallerThanRemainingData)
     --gen.getAuthSize();
 
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldParseCustomQeAuth)
@@ -545,7 +551,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseCustomQeAuth)
     gen.getAuthData().authDataSize += 3; // qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     EXPECT_TRUE(certificationData == quote.getAuthDataV4().certificationData);
 }
 
@@ -562,7 +568,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSi
     gen.getAuthData().authDataSize += 3 + 1; // qeAuthData.size + 1
 
     dcap::Quote quote;
-    EXPECT_FALSE(quote.parse(gen.buildSgxQuote()));
+    EXPECT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSizeAreTooMuch)
@@ -578,8 +584,8 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseWhenQuoteAuthDataSizeMatchButQeAuthDataSi
     gen.getAuthData().authDataSize += 3; // correct qeAuthData.size
 
     dcap::Quote quote;
-	auto builtQuote = gen.buildSgxQuote();
-    EXPECT_FALSE(quote.parse(builtQuote));
+	  const auto [quoteView, builtQuote] = gen.buildSgxQuote();
+    EXPECT_FALSE(quote.parse(quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldParseCertificationData)
@@ -593,7 +599,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseCertificationData)
     gen.getAuthData().authDataSize += 4; // certificationData.size
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     EXPECT_EQ(qeReportCertificationData.certificationData.keyData, quote.getCertificationData().data);
     EXPECT_EQ(qeReportCertificationData.certificationData.keyDataType, quote.getCertificationData().type);
     EXPECT_EQ(qeReportCertificationData.certificationData.size, quote.getCertificationData().parsedDataSize);
@@ -612,7 +618,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseWhenAuthDataSizeMatchButCertificationData
     gen.getAuthData().authDataSize += 4 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_FALSE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseWhenAuthDataSizeMatchButCertificationDataParsedSizeIsTooMuch)
@@ -628,7 +634,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseWhenAuthDataSizeMatchButCertificationData
     gen.getAuthData().authDataSize += 5 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_FALSE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotParseWhenAuthDataSizeMatchButQeAuthDataParsedSizeIsTooMuch)
@@ -644,7 +650,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseWhenAuthDataSizeMatchButQeAuthDataParsedS
     gen.getAuthData().authDataSize += 4 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_FALSE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_FALSE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldParseQeAuthAndQeCert)
@@ -660,7 +666,7 @@ TEST_F(QuoteV5ParsingUT, shouldParseQeAuthAndQeCert)
     gen.getAuthData().authDataSize += 4 + 3; // certificationData.size + qeAuthData.size
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
 }
 
 TEST_F(QuoteV5ParsingUT, shouldNotValidateQeAuthAndQeCertWithUnsupportedType)
@@ -672,7 +678,7 @@ TEST_F(QuoteV5ParsingUT, shouldNotValidateQeAuthAndQeCertWithUnsupportedType)
     gen.withCertificationData(certificationData);
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     ASSERT_FALSE(quote.validate());
 }
 
@@ -682,6 +688,6 @@ TEST_F(QuoteV5ParsingUT, shouldNotParseCertificationDataWithUnsupportedType)
     gen.withCertificationData(certificationData);
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(gen.buildSgxQuote()));
+    ASSERT_TRUE(quote.parse(gen.buildSgxQuote().quoteView));
     ASSERT_FALSE(quote.validate());
 }

--- a/Src/AttestationLibrary/test/UnitTests/QuoteV5VerifierUT.cpp
+++ b/Src/AttestationLibrary/test/UnitTests/QuoteV5VerifierUT.cpp
@@ -33,7 +33,6 @@
 #include <Verifiers/QuoteVerifier.h>
 #include <PckParser/FormatException.h>
 
-#include <utility>
 #include <QuoteVerification/QuoteConstants.h>
 
 #include "Mocks/CertCrlStoresMocks.h"
@@ -43,7 +42,6 @@
 #include "DigestUtils.h"
 #include "QuoteV5Generator.h"
 #include "KeyHelpers.h"
-#include "Constants/QuoteTestConstants.h"
 #include "EcdsaSignatureGenerator.h"
 #include "CertVerification/X509Constants.h"
 
@@ -52,6 +50,9 @@ using namespace dcap::parser::json;
 using namespace ::testing;
 
 namespace {
+    // so there are ByteOperands.h but we just copy these around heh?
+    // i get not to use prod code in tests buy we could just have one copy in test space
+    // instead of multiple copies
 
     uint16_t toUint16(uint8_t leftMostByte, uint8_t rightMostByte)
     {
@@ -112,8 +113,8 @@ struct QuoteV5VerifierUT: public testing::Test
     const std::vector<uint8_t> tdxModuleMrSigner = std::vector<uint8_t>(48, 0x00);
     const std::vector<uint8_t> tdxModuleAttributes = std::vector<uint8_t>(8, 0x00);
     const std::vector<uint8_t> tdxModuleAttributesMask = std::vector<uint8_t>(8, 0xFF);
-    const TdxModule tdxModule = TdxModule(tdxModuleMrSigner, tdxModuleAttributes,
-                                                                                  tdxModuleAttributesMask);
+    const TdxModule tdxModule = TdxModule(tdxModuleMrSigner, tdxModuleAttributes, tdxModuleAttributesMask);
+
     TdxModuleTcbLevel tdxModuleTcbLevel = TdxModuleTcbLevel(
             TdxModuleTcb(2),
             1, "UpToDate", std::vector<std::string>());
@@ -216,36 +217,36 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbInfoMismatchWhenPceIdDoesNotMatch
 
 TEST_F(QuoteV5VerifierUT, shouldReturnStatusInvalidPckCrlWhenPeriodAndIssuerIsInvalid)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::ROOT_CA_CRL_ISSUER));
 
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CRL, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnStatusInvalidPckCrlWhenCrlIssuerIsDifferentThanPck)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::PCK_PLATFORM_CRL_ISSUER));
     EXPECT_CALL(pck, getIssuer()).WillRepeatedly(testing::ReturnRef(dcap::constants::PROCESSOR_CA_SUBJECT));
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CRL, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnStatusPckRevoked)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
 
     EXPECT_CALL(crl, isRevoked(testing::_)).WillOnce(testing::Return(true));
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_PCK_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -253,22 +254,22 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusInvalidQeFormat)
 {
     dcap::Quote quote;
     gen.getAuthData().ecdsaAttestationKey.publicKey = std::array<uint8_t, 64>{};
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QE_REPORT_DATA, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldVerifySgxCorrectly)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     tcbs.insert(tcbs.begin(),
                 TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -285,7 +286,7 @@ TEST_F(QuoteV5VerifierUT, shouldVerifyTdx10Correctly)
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
@@ -296,7 +297,7 @@ TEST_F(QuoteV5VerifierUT, shouldVerifyTdx10Correctly)
     tdxModuleTcbLevels.insert(tdxModuleTcbLevels.begin(), tdxModuleTcbLevel);
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -313,7 +314,7 @@ TEST_F(QuoteV5VerifierUT, shouldVerifyTdx15Correctly)
     gen.withBody({ dcap::constants::BODY_TD_REPORT15_TYPE, dcap::constants::TD_REPORT15_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport15().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx15Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx15Quote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
@@ -322,7 +323,7 @@ TEST_F(QuoteV5VerifierUT, shouldVerifyTdx15Correctly)
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -339,7 +340,7 @@ TEST_F(QuoteV5VerifierUT, shouldVerifyTdx15CorrectlyWhenTdxModuleVersionIsZero)
     gen.withBody({ dcap::constants::BODY_TD_REPORT15_TYPE, dcap::constants::TD_REPORT15_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                gen.getTdReport15().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx15Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx15Quote();
 
     tdxTcbComponents[1] = 0; // 2nd svn zeroed
 
@@ -350,7 +351,7 @@ TEST_F(QuoteV5VerifierUT, shouldVerifyTdx15CorrectlyWhenTdxModuleVersionIsZero)
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -369,7 +370,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedWhenTdx15AndTdxM
     gen.withBody({ dcap::constants::BODY_TD_REPORT15_TYPE, dcap::constants::TD_REPORT15_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                gen.getTdReport15().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx15Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx15Quote();
 
     tdxTcbComponents[1] = 0; // 0 to make sure that expected TDX Module TCB Levels are used.
 
@@ -389,7 +390,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedWhenTdx15AndTdxM
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_TD_RELAUNCH_ADVISED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -408,7 +409,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedWhenTdx15AndTdxM
     gen.withBody({ dcap::constants::BODY_TD_REPORT15_TYPE, dcap::constants::TD_REPORT15_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                gen.getTdReport15().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx15Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx15Quote();
 
     tdxTcbComponents[1] = 1; // 1 to make sure that expected TDX Module TCB Levels are used.
 
@@ -428,7 +429,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedWhenTdx15AndTdxM
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_TD_RELAUNCH_ADVISED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -447,7 +448,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedConfigurationNee
     gen.withBody({ dcap::constants::BODY_TD_REPORT15_TYPE, dcap::constants::TD_REPORT15_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                gen.getTdReport15().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx15Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx15Quote();
 
     tdxTcbComponents[1] = 0; // 0 to make sure that expected TDX Module TCB Levels are used.
 
@@ -467,7 +468,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedConfigurationNee
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_TD_RELAUNCH_ADVISED_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -486,7 +487,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedConfigurationNee
     gen.withBody({ dcap::constants::BODY_TD_REPORT15_TYPE, dcap::constants::TD_REPORT15_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                gen.getTdReport15().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx15Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx15Quote();
 
     tdxTcbComponents[1] = 1; // 1 to make sure that expected TDX Module TCB Levels are used.
 
@@ -506,7 +507,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTcbTdRelaunchAdvisedConfigurationNee
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_TD_RELAUNCH_ADVISED_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -524,7 +525,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTdxModuleMismatchWhenSeamAttricutesN
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
     tdxTcbComponents[1] = 0;
 
     tcbs.insert(tcbs.begin(), TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
@@ -533,7 +534,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTdxModuleMismatchWhenSeamAttricutesN
     auto tdxModuleWithDifferentMask = TdxModule(tdxModule.getMrSigner(), tdxModule.getAttributes(), {0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
     EXPECT_CALL(tcbInfoJson, getTdxModule()).WillOnce(testing::ReturnRef(tdxModuleWithDifferentMask));
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TDX_MODULE_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -546,7 +547,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusQEIdentityMismatchWhenTdxQuoteAndEnc
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{"TDX", sgxTcbComponents, tdxTcbComponents, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
@@ -554,7 +555,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusQEIdentityMismatchWhenTdxQuoteAndEnc
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_QE_IDENTITY_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -572,13 +573,13 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTdxModuleMismatchWhenTdReportMrsigne
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
 
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
     EXPECT_CALL(tcbInfoJson, getVersion()).WillRepeatedly(testing::Return(3));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TDX_MODULE_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -596,13 +597,13 @@ TEST_F(QuoteV5VerifierUT, shouldReturnStatusTdxModuleMismatchWhenTdReportSeamAtt
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
 
     EXPECT_CALL(tcbInfoJson, getId()).WillRepeatedly(testing::Return("TDX"));
     EXPECT_CALL(tcbInfoJson, getVersion()).WillRepeatedly(testing::Return(3));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TDX_MODULE_MISMATCH, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -610,20 +611,20 @@ TEST_F(QuoteV5VerifierUT, shouldReturnInvalidPCKCert)
 {
     const auto emptySubject = dcap::parser::x509::DistinguishedName("", "", "", "", "", "");
     ON_CALL(pck, getSubject()).WillByDefault(testing::ReturnRef(emptySubject));
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_PCK_CERT, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnQuoteInvalidSignature)
 {
     gen.getAuthData().ecdsaSignature.signature[0] = (unsigned char) ~gen.getAuthData().ecdsaSignature.signature[0];
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QUOTE_SIGNATURE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -631,28 +632,28 @@ TEST_F(QuoteV5VerifierUT, shouldReturnInvalidQeReportSignature)
 {
     qeReportCertificationData.qeReportSignature.signature[0] = (unsigned char) ~qeReportCertificationData.qeReportSignature.signature[0];
     certificationData.keyData = qeReportCertificationData.bytes();
-    const auto quoteBin = gen.withCertificationData(certificationData).buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.withCertificationData(certificationData).buildSgxQuote();
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_INVALID_QE_REPORT_SIGNATURE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnTcbRevokedOnLatestRevokedEqualPckTCB)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     tcbs.insert(tcbs.begin(), TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "Revoked"});
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -665,13 +666,13 @@ TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConf
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConfigurationNeededForTcbInfoV2)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -685,13 +686,13 @@ TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnConf
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnOutOfDateConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -705,13 +706,13 @@ TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBWhenBothSVNsAreLowerAndReturnOutO
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_OUT_OF_DATE_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -728,13 +729,13 @@ TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationNeeded)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationAndSwHardeningNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> higherCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x41, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
     std::vector<uint8_t> lowerCpusvn = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x3F, 0x3F, 0x40, 0x3F, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
@@ -751,13 +752,13 @@ TEST_F(QuoteV5VerifierUT, shouldMatchToLowerTCBAndReturnConfigurationAndSwHarden
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_CONFIGURATION_AND_SW_HARDENING_NEEDED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnTcbNotSupportedWhenOnlyPceSvnIsHigher)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     const std::vector<uint8_t> higherPcesvn = {0xff, 0xff};
 
@@ -765,13 +766,13 @@ TEST_F(QuoteV5VerifierUT, shouldReturnTcbNotSupportedWhenOnlyPceSvnIsHigher)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_NOT_SUPPORTED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnTcbRevokedWhenOnlyCpuSvnIsLower)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -780,13 +781,13 @@ TEST_F(QuoteV5VerifierUT, shouldReturnTcbRevokedWhenOnlyCpuSvnIsLower)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnTcbRevokedWhenOnlyPcesvnIsLower)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     const std::vector<uint8_t> lowerPcesvn = {0x21, 0x12};
 
@@ -794,13 +795,13 @@ TEST_F(QuoteV5VerifierUT, shouldReturnTcbRevokedWhenOnlyPcesvnIsLower)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_REVOKED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldNOTReturnTcbRevokedWhenRevokedPcesvnAndCpusvnAreLower)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -812,13 +813,13 @@ TEST_F(QuoteV5VerifierUT, shouldNOTReturnTcbRevokedWhenRevokedPcesvnAndCpusvnAre
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_OK, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
 TEST_F(QuoteV5VerifierUT, shouldReturnSwHardeningNeeded)
 {
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
 
     std::vector<uint8_t> lowerCpusvn = cpusvn;
     lowerCpusvn[8]--;
@@ -829,7 +830,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnSwHardeningNeeded)
     EXPECT_CALL(tcbInfoJson, getTcbLevels()).WillOnce(testing::ReturnRef(tcbs));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_SW_HARDENING_NEEDED , dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -845,9 +846,9 @@ struct QuoteV5VerifierUTQeIdentityStatusParametrized : public QuoteV5VerifierUT,
 TEST_P(QuoteV5VerifierUTQeIdentityStatusParametrized, testAllStatuses)
 {
     auto params = GetParam();
-    const auto quoteBin = gen.buildSgxQuote();
+    const auto [quoteView, quoteBin] = gen.buildSgxQuote();
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     tcbs.insert(tcbs.begin(), TcbLevel{cpusvn, toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
 
     tdxTcbComponents[1] = 0; // 0 to make sure that expected tcb levels are used. 1 would use TDX Module TCB Levels
@@ -874,7 +875,7 @@ TEST_F(QuoteV5VerifierUT, shouldBackoffToLowerLevelBecauseTdReportTeeSvnIsOutOfD
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
 
     tdxTcbComponents[1] = 0; // 0 to make sure that expected tcb levels are used. 1 would use TDX Module TCB Levels
 
@@ -887,7 +888,7 @@ TEST_F(QuoteV5VerifierUT, shouldBackoffToLowerLevelBecauseTdReportTeeSvnIsOutOfD
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_OUT_OF_DATE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -904,7 +905,7 @@ TEST_F(QuoteV5VerifierUT, shouldBackoffToLowerLevelBecauseNoAllSvnsAreHigher)
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
     tdxTcbComponents[1] = 0; // 0 to make sure that expected tcb levels are used. 1 would use TDX Module TCB Levels
     std::vector<TcbComponent> tdxComponents = {0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
@@ -917,7 +918,7 @@ TEST_F(QuoteV5VerifierUT, shouldBackoffToLowerLevelBecauseNoAllSvnsAreHigher)
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_OUT_OF_DATE, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 
@@ -934,7 +935,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnTcbNotSupportedIfNotMatchingTcbLevelIsFoun
     gen.withBody({ dcap::constants::BODY_TD_REPORT10_TYPE, dcap::constants::TD_REPORT10_BYTE_LEN });
     gen.getAuthData().ecdsaSignature.signature = signAndGetRaw(gen.getHeader().bytes() + gen.getBody().bytes() +
                                                                        gen.getTdReport10().bytes(), *privKey);
-    const auto quoteBin = gen.buildTdx10Quote();
+    const auto [quoteView, quoteBin] = gen.buildTdx10Quote();
 
     tcbs.insert(TcbLevel{"TDX", sgxTcbComponents, std::vector<TcbComponent>(16, TcbComponent(0xF0)), toUint16(pcesvn[1], pcesvn[0]), "UpToDate"});
     tcbs.insert(TcbLevel{"TDX", sgxTcbComponents, std::vector<TcbComponent>(16, TcbComponent(0x60)), toUint16(pcesvn[1], pcesvn[0]), "OutOfDate"});
@@ -945,7 +946,7 @@ TEST_F(QuoteV5VerifierUT, shouldReturnTcbNotSupportedIfNotMatchingTcbLevelIsFoun
     EXPECT_CALL(enclaveIdentityV2, getID()).WillOnce(testing::Return(EnclaveID::TD_QE));
 
     dcap::Quote quote;
-    ASSERT_TRUE(quote.parse(quoteBin));
+    ASSERT_TRUE(quote.parse(quoteView));
     EXPECT_EQ(STATUS_TCB_NOT_SUPPORTED, dcap::QuoteVerifier{}.verify(quote, pck, crl, tcbInfoJson, &enclaveIdentityV2, enclaveReportVerifier));
 }
 


### PR DESCRIPTION
When parsing quote, library creates internal copy which is used for parsing. This is unnecessary and I'm addressing this in this PR. All tests pass.