### PR TITLE
Generate compile_commands.json for clangd based LSPs by default

### DIFF
--- a/Src/.gitignore
+++ b/Src/.gitignore
@@ -3,6 +3,7 @@ Version/include
 Build
 cmake-build-debug
 cmake-build-release
+compile_commands.json
 .vscode
 x64
 Debug

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, Intel Corporation
+# Copyright (c) 2017 - 2026, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -26,6 +26,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 set(CMAKE_POLICY_DEFAULT_CMP0144 NEW)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(ATTESTATION_PARSERS_ROOT_DIR "") # Optional path to Attestation Parsers library
 set(ATTESTATION_LIBRARY_ROOT_DIR "") # Optional path to Attestation library


### PR DESCRIPTION
Additionally add `compile_commands.json` file name to `.gitignore` list so it's more ergonomic to create a symbolic in a place of most convenience for each developer.